### PR TITLE
Proposal for Datum Connectors

### DIFF
--- a/enhancements/networking/connectors/initial-proposal/README.md
+++ b/enhancements/networking/connectors/initial-proposal/README.md
@@ -235,8 +235,13 @@ status:
   connectionDetails:
     type: PublicKey
     publicKey:
-      value: 2ovpybgj3snjmchns44pfn6dbwmdiu4ogfd66xyu72ghexllv6hq
+      id: 2ovpybgj3snjmchns44pfn6dbwmdiu4ogfd66xyu72ghexllv6hq
       discoveryMode: DNS
+      homeRelay: https://use1-1.relay.n0.iroh.iroh.link
+      addresses:
+        - 151.113.91.155
+        - a64a:948d:36c5:8933:7368:e5cf:cd3f:baab
+
 ```
 
 [grpc-health]: https://github.com/grpc/grpc-proto/blob/master/grpc/health/v1/health.proto


### PR DESCRIPTION
From the document's summary:

Datum Connectors introduce a method to model outbound connectivity as first class resources in the control plane. A Connector resource lives in a project and captures what kinds of network access it can facilitate, while ConnectorAdvertisement resources describe the networks and endpoints that are reachable through that connector. Other platform components, such as proxies, can then target backends via these connectors, allowing the control plane to reason about and route traffic to remote or otherwise inaccessible environments.

A Connector will always be managed by a controller responsible for maintaining its lifecycle, capabilities, advertisements, and health state in the control plane. The first controller implementation will be the [Datum Connect][datum-connect] application, which will register and manage Connector, ConnectorAdvertisement, and HTTPProxy resources.

[datum-connect]: https://github.com/datum-cloud/datum-connect

Related work:
  - [Datum Network Services Research](https://github.com/datum-cloud/enhancements/tree/main/enhancements/networking/research/datum-network-services)
  - https://github.com/datum-cloud/enhancements/issues/87
  - https://github.com/datum-cloud/datum-connect