### PR TITLE
feat: primary and secondary zone transfers

### DIFF
--- a/enhancements/authoritative-dns/zone-transfers/README.md
+++ b/enhancements/authoritative-dns/zone-transfers/README.md
@@ -214,8 +214,9 @@ spec:
   # Exactly one of 'secondary' or 'primary' must be specified, matching 'role'
   secondary:
     masters:
-      - 198.51.100.10
-      - 198.51.100.11
+      - address: 198.51.100.10
+      - address: 198.51.100.11
+        port: 5353
     tsigKeyRef:
       name: example-com-upstream
   # primary:
@@ -230,6 +231,8 @@ Rules:
 - At most one `ZoneTransfer` with `role: Secondary` per `DNSZone` (v1).
 - At most one `ZoneTransfer` with `role: Primary` per `DNSZone` (v1).
 - `secondary` requires non-empty `masters` and a `tsigKeyRef`.
+  - `masters[*].address` is required (IPv4/IPv6 or hostname).
+  - `masters[*].port` is optional; defaults to 53; valid range 1–65535.
 - `primary` requires a `tsigKeyRef`.
 - `spec.dnsZoneRef` must reference a `DNSZone` in the same namespace.
 
@@ -296,8 +299,9 @@ spec:
   role: Secondary
   secondary:
     masters:
-      - 198.51.100.10
-      - 198.51.100.11
+      - address: 198.51.100.10
+      - address: 198.51.100.11
+        port: 5353
     tsigKeyRef:
       name: example-com-upstream
 ```


### PR DESCRIPTION
This enhancement proposes a model for Primary and Secondary DNS Zone transfers. It introduces DNSZone (Primary/Secondary roles) and TSIGKey (with zoneRef ownership) to require TSIG for Secondary imports and enable optional outbound transfers for Primaries. Transfers run on a dedicated xfr1 transfer plane while anycast edges remain serve-only, improving security and multi-tenant safety with a default-deny posture and presence-implies-intent config. The goal is a secure, reliable, and maintainable foundation for DNS at Datum that maps to PowerDNS initially and remains provider-agnostic over time.