### PR TITLE
Workload Identity Federation for External Platform Authentication

### DIFF
--- a/enhancements/platform/identity-and-access-management/README.md
+++ b/enhancements/platform/identity-and-access-management/README.md
@@ -195,3 +195,5 @@ In the future we will also support the following formats to support additional
 use-cases.
 
 - `group:<group-email>` grants a group in the IAM system access to a role
+- `principal:<principal-uri>` grants a federated identity access to a role (see
+  [Workload Identity Federation](./workload-identity-federation/))

--- a/enhancements/platform/identity-and-access-management/workload-identity-federation/README.md
+++ b/enhancements/platform/identity-and-access-management/workload-identity-federation/README.md
@@ -1,0 +1,491 @@
+---
+status: provisional
+stage: alpha
+latest-milestone: "v0.1"
+---
+
+<!-- omit from toc -->
+# Workload Identity Federation
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [How It Works](#how-it-works)
+  - [User Stories](#user-stories)
+  - [Supported Platforms](#supported-platforms)
+  - [Security](#security)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+- [Design Details](#design-details)
+  - [Resource Model](#resource-model)
+  - [Authentication Flow](#authentication-flow)
+  - [Authorization Integration](#authorization-integration)
+  - [Attribute-Based Access Control](#attribute-based-access-control)
+- [Future Work](#future-work)
+- [Dependencies](#dependencies)
+- [Alternatives](#alternatives)
+
+## Summary
+
+Workload Identity Federation enables external platforms (GitHub Actions, GCP,
+AWS, Azure) to authenticate to Milo using their native OIDC tokens instead of
+long-lived credentials. Project owners configure trust relationships through
+WorkloadIdentityPool and WorkloadIdentityPoolProvider resources, and federated
+identities become subjects in PolicyBindings using principal URI strings.
+
+This approach eliminates credential management burden, removes the need to store
+secrets in CI/CD systems, and provides automatic token expiration with clear
+audit attribution.
+
+## Motivation
+
+Many teams need external platforms to access their Milo projects for CI/CD
+pipelines, automation, and third-party integrations. Common scenarios include:
+
+- **GitHub Actions workflows** deploying resources to a project
+- **Cloud platform workloads** (GCP Cloud Functions, AWS Lambda) calling Milo
+  APIs
+- **Third-party services** like Grafana reading project metrics
+
+Today, these use cases require creating MachineAccounts with long-lived
+MachineAccountKeys. This approach has significant problems:
+
+- **Credential management burden**: Teams must generate, store, rotate, and
+  revoke keys manually
+- **Secret exposure risk**: Keys stored in CI/CD systems can leak through logs,
+  breaches, or misconfiguration
+- **Audit difficulty**: Attributing actions to specific CI/CD runs is harder
+  with shared credentials
+- **No automatic expiration**: Keys remain valid until manually revoked,
+  creating persistent risk
+
+Workload Identity Federation solves these problems by letting external platforms
+authenticate using their native short-lived OIDC tokens. A GitHub Actions
+workflow uses its job token; a GCP Cloud Function uses its service identity
+token. No long-lived credentials are shared or stored.
+
+### Goals
+
+- Enable external workloads to authenticate using native OIDC tokens
+- Provide project owners with control over which external identities can access
+  their projects
+- Support attribute-based access control using OIDC token claims (repository,
+  branch, actor)
+- Integrate with existing PolicyBinding authorization model
+- Support GitHub Actions, GCP, AWS, and Azure as initial platforms
+
+### Non-Goals
+
+- Replacing user authentication (human users continue using existing auth)
+- Replacing [Platform Workload Identity][platform-workload-identity] for
+  internal service-to-service authentication
+- Organization-level identity pools (project-scoped only for v1)
+- Non-OIDC federation protocols (SAML, X.509)
+- Custom OIDC providers with arbitrary issuers (security risk)
+
+## Proposal
+
+Workload Identity Federation introduces two resources that project owners use to
+configure trust relationships with external identity providers:
+
+- **WorkloadIdentityPool**: Groups related external identity providers
+- **WorkloadIdentityPoolProvider**: Configures a specific OIDC issuer with
+  attribute conditions
+
+When an external workload presents an OIDC token, Milo validates it against
+matching providers and constructs a principal URI. This principal URI becomes a
+subject in PolicyBindings, granting the federated identity access to project
+resources.
+
+### How It Works
+
+**Setup (one-time):**
+
+1. Project owner creates a WorkloadIdentityPool to group related providers
+2. Project owner creates a WorkloadIdentityPoolProvider specifying the OIDC
+   issuer and attribute conditions
+3. Project owner creates a PolicyBinding granting the principal access to
+   resources
+
+**Runtime (every request):**
+
+1. External workload requests OIDC token from its platform (automatic in GitHub
+   Actions)
+2. Workload calls Milo API with token in Authorization header
+3. Milo validates token against matching provider
+4. Milo constructs principal URI and checks PolicyBinding authorization
+5. Request proceeds with federated identity context
+
+### User Stories
+
+#### Deploy from GitHub Actions
+
+As a developer, I want my GitHub Actions workflow to deploy resources to my Milo
+project without storing credentials as secrets.
+
+**Experience:**
+
+```yaml
+# .github/workflows/deploy.yml
+jobs:
+  deploy:
+    permissions:
+      id-token: write  # Request OIDC token
+    steps:
+      - uses: datum-cloud/auth-action@v1
+        with:
+          project: my-project
+          pool: ci-cd-pool
+          provider: github-actions-main
+      - run: datumctl apply -f manifests/
+```
+
+The workflow authenticates using its native GitHub OIDC token. No secrets
+configuration required.
+
+#### Restrict Access by Branch
+
+As a team lead, I want to grant deploy access only to workflows running on the
+main branch, while allowing any branch to run read-only operations.
+
+**Experience:** Create two providers with different attribute conditions:
+
+- `github-actions-main`: Condition requires `attribute.ref ==
+  "refs/heads/main"` → bound to deployer role
+- `github-actions-all`: No branch restriction → bound to viewer role
+
+Workflows on feature branches can view resources but cannot deploy.
+
+#### Authenticate from GCP Cloud Functions
+
+As a developer, I want my GCP Cloud Function to call Milo APIs using its service
+identity without embedding credentials in code.
+
+**Experience:** Create a provider for the GCP issuer with a condition matching
+the service account email. The Cloud Function authenticates using its native
+identity token.
+
+#### Revoke Access Immediately
+
+As a security engineer, I want to immediately revoke access for a compromised
+workflow without waiting for credential expiration.
+
+**Experience:** Delete the PolicyBinding or disable the
+WorkloadIdentityPoolProvider. Access is denied immediately on the next request,
+even though the OIDC token may still be valid.
+
+#### Audit CI/CD Activity
+
+As a compliance officer, I want to see which CI/CD workflows accessed my project
+and what actions they performed.
+
+**Experience:** View the Activity timeline filtered by principal. Each action
+shows the principal URI, which encodes the pool and provider. Cross-reference
+with CI/CD logs to identify specific workflow runs.
+
+### Supported Platforms
+
+Initial support targets platforms with mature OIDC token support:
+
+| Platform | Issuer | Key Claims |
+|----------|--------|------------|
+| **GitHub Actions** | `https://token.actions.githubusercontent.com` | `repository`, `repository_owner`, `ref`, `workflow`, `actor` |
+| **GCP** | `https://accounts.google.com` | `email`, `sub` (service account) |
+| **AWS** | `https://sts.amazonaws.com` | Role ARN in `sub` |
+| **Azure AD** | `https://login.microsoftonline.com/{tenant}/v2.0` | `sub`, `oid`, `appid` |
+
+These platforms automatically provide OIDC tokens to workloads without
+additional configuration.
+
+### Security
+
+#### Trust Model
+
+- **Token validation**: Signature verified using JWKS from issuer
+- **Issuer validation**: Token's `iss` claim must match provider's configured
+  issuer
+- **Audience validation**: Token's `aud` claim must match configured audiences
+- **Expiration**: Tokens older than 1 hour are rejected
+- **Attribute conditions**: CEL expressions evaluated before authentication
+  succeeds
+
+#### No Credential Storage
+
+Unlike MachineAccountKeys, no credentials are stored in Milo or external
+systems. OIDC tokens are:
+
+- **Short-lived**: Typically 10-60 minutes
+- **Automatically provisioned**: Platforms issue tokens without user action
+- **Cryptographically signed**: Cannot be forged without the issuer's private
+  key
+
+#### Revocation
+
+Access can be revoked through multiple mechanisms:
+
+| Mechanism | Effect | Latency |
+|-----------|--------|---------|
+| Delete PolicyBinding | Authorization denied | Immediate |
+| Disable provider | Authentication rejected | Immediate |
+| Delete provider | Authentication rejected | Immediate |
+| Disable pool | All providers in pool rejected | Immediate |
+
+Unlike long-lived credentials, there's no need to rotate secrets or wait for
+expiration.
+
+### Notes/Constraints/Caveats
+
+#### Project Control Plane Scope
+
+WorkloadIdentityPool and WorkloadIdentityPoolProvider are cluster-scoped within
+a project's control plane. Since projects are dedicated control planes in Milo,
+these resources are naturally project-scoped without requiring namespaces.
+
+#### Attribute Conditions at Authentication Time
+
+Attribute conditions (CEL expressions) are evaluated during authentication, not
+authorization. This means:
+
+- All tokens from a provider share the same principal URI
+- To grant different permissions based on attributes (e.g., branch), create
+  separate providers
+
+Future work may add binding-level conditions for finer-grained control.
+
+#### JWKS Caching
+
+JWKS (JSON Web Key Sets) are cached for 1 hour to reduce latency and external
+dependencies. The cache is invalidated on signature validation failures,
+ensuring key rotation is handled gracefully.
+
+### Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| **Overly permissive conditions** | Unintended access granted | Conditions are required; validation rejects empty conditions |
+| **JWKS endpoint unavailable** | New tokens cannot validate | Cache last-known-good JWKS; tokens cached during outage |
+| **Token replay** | Same token reused maliciously | Short token lifetime (1 hour max); `exp` claim enforced |
+| **Issuer spoofing** | Fake tokens accepted | JWKS fetched only from configured issuer over HTTPS |
+| **Misconfigured provider** | Authentication failures | Status conditions surface configuration errors |
+
+## Design Details
+
+### Resource Model
+
+#### WorkloadIdentityPool
+
+Groups related identity providers and provides a common point of control (e.g.,
+emergency disable).
+
+```yaml
+apiVersion: iam.miloapis.com/v1alpha1
+kind: WorkloadIdentityPool
+metadata:
+  name: ci-cd-pool
+spec:
+  displayName: "CI/CD Workload Pool"
+  description: "Pool for CI/CD pipeline authentications"
+  disabled: false  # Emergency disable switch
+status:
+  providerCount: 2
+  conditions:
+    - type: Ready
+      status: "True"
+```
+
+#### WorkloadIdentityPoolProvider
+
+Configures trust for a specific OIDC issuer with attribute mapping and
+conditions.
+
+```yaml
+apiVersion: iam.miloapis.com/v1alpha1
+kind: WorkloadIdentityPoolProvider
+metadata:
+  name: github-actions-main
+spec:
+  poolRef:
+    name: ci-cd-pool
+
+  displayName: "GitHub Actions - Main Branch"
+
+  oidc:
+    issuerUri: "https://token.actions.githubusercontent.com"
+    allowedAudiences:
+      - "https://api.miloapis.com"
+
+  # Map token claims to attributes
+  attributeMapping:
+    attribute.repository: "assertion.repository"
+    attribute.repository_owner: "assertion.repository_owner"
+    attribute.ref: "assertion.ref"
+    attribute.actor: "assertion.actor"
+
+  # CEL expression: tokens must satisfy this condition
+  attributeCondition: |
+    attribute.repository == "acme-corp/infrastructure" &&
+    attribute.ref == "refs/heads/main"
+
+status:
+  principalIdentifier: "principal://iam.miloapis.com/projects/my-project/pools/ci-cd-pool/providers/github-actions-main"
+  resolvedJwksUri: "https://token.actions.githubusercontent.com/.well-known/jwks"
+  conditions:
+    - type: Ready
+      status: "True"
+```
+
+### Authentication Flow
+
+```
+┌─────────────┐                  ┌──────────────────┐                  ┌─────────────┐
+│   GitHub    │                  │   Milo API       │                  │   GitHub    │
+│   Actions   │                  │   Server         │                  │   OIDC      │
+└─────────────┘                  └──────────────────┘                  └─────────────┘
+       │                                  │                                     │
+       │  1. Request OIDC token           │                                     │
+       │────────────────────────────────────────────────────────────────────────>│
+       │                                  │                                     │
+       │  2. OIDC token (signed JWT)      │                                     │
+       │<────────────────────────────────────────────────────────────────────────│
+       │                                  │                                     │
+       │  3. API request                  │                                     │
+       │     Authorization: Bearer <jwt>  │                                     │
+       │─────────────────────────────────>│                                     │
+       │                                  │                                     │
+       │                                  │  4. Fetch JWKS (cached)             │
+       │                                  │────────────────────────────────────>│
+       │                                  │                                     │
+       │                                  │  5. Validate signature, claims      │
+       │                                  │  6. Extract attributes              │
+       │                                  │  7. Evaluate CEL condition          │
+       │                                  │  8. Construct principal URI         │
+       │                                  │  9. Check PolicyBinding (OpenFGA)   │
+       │                                  │                                     │
+       │  10. API response                │                                     │
+       │<─────────────────────────────────│                                     │
+```
+
+### Authorization Integration
+
+Federated identities become subjects in PolicyBindings using principal URI
+strings:
+
+```yaml
+apiVersion: iam.miloapis.com/v1alpha1
+kind: PolicyBinding
+metadata:
+  name: github-deployer
+spec:
+  roleRef:
+    name: project-editor
+  subjects:
+    - kind: Principal
+      name: "principal://iam.miloapis.com/projects/my-project/pools/ci-cd-pool/providers/github-actions-main"
+  resourceSelector:
+    resourceKind:
+      apiGroup: resourcemanager.miloapis.com
+      kind: Project
+```
+
+The principal URI format follows GCP's proven pattern:
+
+```
+principal://iam.miloapis.com/projects/{project}/pools/{pool}/providers/{provider}
+```
+
+Including the project in the URI ensures principals are globally unique across
+the platform. This format is extensible for future enhancements like
+`principalSet://` for attribute-based principal matching.
+
+### Attribute-Based Access Control
+
+CEL (Common Expression Language) provides attribute-based access control at
+authentication time:
+
+- **Single repository**: `attribute.repository == "acme-corp/app"`
+- **Organization-wide**: `attribute.repository.startsWith("acme-corp/")`
+- **Main branch only**: `attribute.ref == "refs/heads/main"`
+- **Release tags**: `attribute.ref.startsWith("refs/tags/v")`
+- **Specific actor**: `attribute.actor == "deploy-bot"`
+- **Combined**: `attribute.repository == "acme-corp/app" && attribute.ref == "refs/heads/main"`
+
+Conditions are required—providers without conditions are rejected during
+validation.
+
+## Future Work
+
+The MVP focuses on OIDC federation for CI/CD platforms. Future phases will
+expand based on customer feedback:
+
+**Binding-level conditions:**
+
+- CEL conditions on PolicyBinding subjects for finer-grained authorization
+- Requires OpenFGA integration design
+- Enables different permissions based on attributes without multiple providers
+
+**Organization-level pools:**
+
+- Shared pools across projects within an organization
+- Centralized trust management for platform teams
+
+**Additional platforms:**
+
+- Custom OIDC providers (user-defined issuers with security guardrails)
+- Grafana and other SaaS provider integrations
+- SAML and X.509 provider types
+
+**Enhanced matching:**
+
+- `principalSet://` URIs for attribute-based principal matching (GCP pattern)
+- Wildcard pool matching
+
+## Dependencies
+
+Workload Identity Federation builds on existing platform services:
+
+- **IAM**: PolicyBindings grant permissions to federated identities
+- **Activity**: Authentication events appear in audit timeline
+- **OpenFGA**: Authorization checks use principal URIs as subjects
+
+External dependencies:
+
+- **Identity provider OIDC endpoints**: JWKS and token issuance
+- **CEL library**: Expression evaluation (`github.com/google/cel-go`)
+- **JWT library**: Token parsing and validation (`github.com/golang-jwt/jwt/v5`)
+
+## Alternatives
+
+### Per-Consumer Credentials (Current Approach)
+
+Create MachineAccounts with MachineAccountKeys for each external platform.
+
+**Rejected because:**
+
+- Credential management burden (rotation, storage, revocation)
+- Long-lived secrets create persistent security risk
+- Audit attribution is difficult with shared credentials
+
+### OAuth Client Credentials
+
+External platforms obtain tokens via OAuth client credentials flow.
+
+**Rejected because:**
+
+- Still requires managing client secrets
+- More complex than native OIDC token support
+- Platforms already provide OIDC tokens automatically
+
+### Service Mesh / SPIFFE
+
+Use SPIFFE IDs and service mesh for workload identity.
+
+**Rejected because:**
+
+- Requires external platforms to participate in service mesh
+- Additional infrastructure complexity
+- OIDC is already the industry standard for CI/CD federation
+
+<!-- References -->
+[platform-workload-identity]: ../workload-identity/README.md

--- a/enhancements/platform/identity-and-access-management/workload-identity-federation/README.md
+++ b/enhancements/platform/identity-and-access-management/workload-identity-federation/README.md
@@ -35,7 +35,7 @@ Workload Identity Federation enables external platforms (GitHub Actions, GCP,
 AWS, Azure) to authenticate to Milo using their native OIDC tokens instead of
 long-lived credentials. Platform administrators register trusted OIDC issuers
 once, centrally. Project owners enable one of those issuers within their
-project and define WorkloadIdentityPoolRules that match specific tokens —
+project and define WorkloadIdentityRules that match specific tokens —
 by audience, claims, or CEL attribute conditions — to a federated identity.
 Federated identities become subjects in PolicyBindings using principal URI
 strings.
@@ -88,7 +88,6 @@ token. No long-lived credentials are shared or stored.
   internal service-to-service authentication
 - Organization-level identity pools (project-scoped only for v1)
 - Non-OIDC federation protocols (SAML, X.509)
-- Custom OIDC providers with arbitrary issuers (security risk)
 
 ## Proposal
 
@@ -99,17 +98,19 @@ so a single issuer registration can back many different access levels without
 duplicating issuer configuration:
 
 - **TrustedIssuer** *(platform-level)*: Registers an OIDC issuer's identity
-  (issuer URL and JWKS source) as safe to federate against. Managed by
-  platform administrators. v1 ships TrustedIssuers for the platforms in
-  [Supported Platforms](#supported-platforms); project-defined custom issuers
-  are [Future Work](#future-work).
+  (issuer URL and JWKS source) as safe to federate against, cluster-wide.
+  Managed by platform administrators. v1 ships TrustedIssuers for the
+  platforms in [Supported Platforms](#supported-platforms).
 - **WorkloadIdentityPool** *(project-level, optional)*: Groups related issuers
   and rules for bulk enable/disable. Projects that don't need grouping can
   omit it; ungrouped resources are placed in an implicit `default` pool so the
   principal URI shape never changes.
-- **WorkloadIdentityPoolIssuer** *(project-level)*: Enables a TrustedIssuer
-  for use within a project's pool.
-- **WorkloadIdentityPoolRule** *(project-level)*: Matches tokens from a
+- **WorkloadIdentityIssuer** *(project-level)*: Enables a TrustedIssuer for
+  use within a project's pool, or registers a project-owned custom OIDC
+  issuer directly (its own issuer URL and JWKS source) for identity providers
+  the platform hasn't pre-vetted — a private Kubernetes cluster, SPIRE, Okta,
+  or any other standards-compliant issuer.
+- **WorkloadIdentityRule** *(project-level)*: Matches tokens from a
   specific issuer against audience, claim, and CEL attribute conditions, and
   maps matching tokens to a principal URI.
 
@@ -124,10 +125,10 @@ resources.
 
 1. Platform administrator registers a TrustedIssuer (already done for
    supported platforms in v1)
-2. Project owner creates a WorkloadIdentityPoolIssuer enabling that
+2. Project owner creates a WorkloadIdentityIssuer enabling that
    TrustedIssuer within the project (optionally within a named
    WorkloadIdentityPool)
-3. Project owner creates one or more WorkloadIdentityPoolRules specifying
+3. Project owner creates one or more WorkloadIdentityRules specifying
    audience, claim, and attribute conditions
 4. Project owner creates a PolicyBinding granting the resulting principal
    access to resources
@@ -175,8 +176,8 @@ configuration required.
 As a team lead, I want to grant deploy access only to workflows running on the
 main branch, while allowing any branch to run read-only operations.
 
-**Experience:** Create one WorkloadIdentityPoolIssuer for GitHub Actions, then
-two WorkloadIdentityPoolRules against it with different attribute conditions:
+**Experience:** Create one WorkloadIdentityIssuer for GitHub Actions, then
+two WorkloadIdentityRules against it with different attribute conditions:
 
 - `github-actions-main`: Condition requires `attribute.ref ==
   "refs/heads/main"` → bound to deployer role
@@ -188,7 +189,7 @@ deploy.
 
 #### Verify a New Rule Before Relying On It
 
-As a developer, I want to confirm my WorkloadIdentityPoolRule is configured
+As a developer, I want to confirm my WorkloadIdentityRule is configured
 correctly before I point a real CI/CD pipeline at it.
 
 **Experience:** After creating the issuer and rule, select **Test rule** in
@@ -204,9 +205,22 @@ the rule persists and the test can be re-run from the rule's detail page.
 As a developer, I want my GCP Cloud Function to call Milo APIs using its service
 identity without embedding credentials in code.
 
-**Experience:** Create a WorkloadIdentityPoolIssuer referencing the GCP
+**Experience:** Create a WorkloadIdentityIssuer referencing the GCP
 TrustedIssuer, then a rule with a condition matching the service account
 email. The Cloud Function authenticates using its native identity token.
+
+#### Authenticate from a Private Kubernetes Cluster
+
+As a platform engineer, I want workloads in our on-prem Kubernetes cluster to
+authenticate using projected service account tokens, even though our cluster
+isn't reachable from the public internet and isn't one of Milo's pre-vetted
+platforms.
+
+**Experience:** Create a WorkloadIdentityIssuer with a custom `oidc` block —
+issuer URL and an `inline` JWKS document, since the cluster's discovery
+endpoint isn't publicly reachable — instead of a `trustedIssuerRef`. Run
+**Verify issuer** to confirm the JWKS parses correctly, then create a rule
+scoped to the cluster's service account subjects, same as any other issuer.
 
 #### Revoke Access Immediately
 
@@ -214,7 +228,7 @@ As a security engineer, I want to immediately revoke access for a compromised
 workflow without waiting for credential expiration.
 
 **Experience:** Delete the PolicyBinding or disable the
-WorkloadIdentityPoolRule. Access is denied immediately on the next request,
+WorkloadIdentityRule. Access is denied immediately on the next request,
 even though the OIDC token may still be valid.
 
 #### Audit CI/CD Activity
@@ -243,16 +257,20 @@ pre-registered as a platform-level TrustedIssuer:
 
 These platforms automatically provide OIDC tokens to workloads without
 additional configuration. Project owners reference the corresponding
-TrustedIssuer from a WorkloadIdentityPoolIssuer; they do not configure issuer
-URLs or JWKS sources directly in v1.
+TrustedIssuer from a WorkloadIdentityIssuer and skip issuer/JWKS
+configuration entirely. Any other standards-compliant OIDC issuer — a private
+Kubernetes cluster, SPIRE, Okta, or a self-hosted IdP — is supported from v1
+by registering it directly on a WorkloadIdentityIssuer instead of referencing
+a TrustedIssuer.
 
 ### Security
 
 #### Trust Model
 
 - **Token validation**: Signature verified using JWKS from issuer
-- **Issuer validation**: Token's `iss` claim must match the TrustedIssuer's
-  configured issuer
+- **Issuer validation**: Token's `iss` claim must match the issuer configured
+  on the WorkloadIdentityIssuer — whether that's a referenced TrustedIssuer or
+  a project-owned custom issuer
 - **Audience validation**: Token's `aud` claim must match configured audiences
 - **Expiration**: Tokens older than 1 hour are rejected
 - **Attribute conditions**: CEL expressions evaluated before authentication
@@ -287,7 +305,7 @@ expiration.
 
 #### Project Control Plane Scope
 
-WorkloadIdentityPool, WorkloadIdentityPoolIssuer, and WorkloadIdentityPoolRule
+WorkloadIdentityPool, WorkloadIdentityIssuer, and WorkloadIdentityRule
 are cluster-scoped within a project's control plane. Since projects are
 dedicated control planes in Milo, these resources are naturally project-scoped
 without requiring namespaces. TrustedIssuer is the one exception: it is a
@@ -296,16 +314,28 @@ platform-level resource managed outside any project's control plane.
 #### Pools Are Optional
 
 WorkloadIdentityPool exists purely for grouping and bulk enable/disable.
-WorkloadIdentityPoolIssuer and WorkloadIdentityPoolRule may omit `poolRef`
+WorkloadIdentityIssuer and WorkloadIdentityRule may omit `poolRef`
 entirely, in which case they're placed in an implicit `default` pool scoped to
 the project. This keeps the principal URI shape
 (`principal://.../pools/{pool}/rules/{rule}`) stable whether or not a project
 ever creates an explicit pool, and avoids requiring pool creation for the
 common single-issuer, single-rule case.
 
+#### Custom Issuers Go Through the Same Verification Path
+
+A project-owned custom issuer on WorkloadIdentityIssuer carries its own
+`issuerUri` and `jwks` source (`discovery`, `explicitUrl`, or `inline`, same
+options as TrustedIssuer), and is subject to the same constraints: `https`,
+port 443, and a public DNS hostname resolving to public IPs — no IP literals
+— for anything Milo fetches directly. `explicitUrl` and `inline` modes exist
+for issuers unreachable from the public internet (a private Kubernetes
+cluster, for example), where `issuerUri` is compared as a string rather than
+fetched. Custom issuers go through the same **Verify issuer** dry-run as a
+TrustedIssuer before they can back a rule.
+
 #### Audiences Are a Rule-Level Match Condition
 
-Allowed audiences are configured per WorkloadIdentityPoolRule, not on the
+Allowed audiences are configured per WorkloadIdentityRule, not on the
 issuer. This lets two rules against the same issuer require different
 audiences (for example, a stricter audience for a deployer rule than for a
 read-only rule) without duplicating issuer configuration, and keeps audience
@@ -336,7 +366,8 @@ ensuring key rotation is handled gracefully.
 | **Overly permissive conditions** | Unintended access granted | Conditions are required; validation rejects empty conditions |
 | **JWKS endpoint unavailable** | New tokens cannot validate | Cache last-known-good JWKS; tokens cached during outage |
 | **Token replay** | Same token reused maliciously | Short token lifetime (1 hour max); `exp` claim enforced |
-| **Issuer spoofing** | Fake tokens accepted | JWKS fetched only from configured issuer over HTTPS; v1 issuers are limited to platform-vetted TrustedIssuers |
+| **Issuer spoofing** | Fake tokens accepted | JWKS fetched only from the configured issuer over HTTPS; the same `https`/port-443/public-DNS constraints and `Verify issuer` dry-run apply whether the issuer is a platform TrustedIssuer or a project-owned custom issuer |
+| **Malicious or typo'd custom issuer URL** | Project registers an issuer that resolves somewhere unintended, or never resolves | `Verify issuer` dry-run required before a custom issuer can back a rule; URL constraints reject IP literals and non-HTTPS/443 endpoints; a custom issuer is scoped to the project that registered it and cannot be referenced by other projects |
 | **Misconfigured rule** | Authentication failures | Status conditions surface configuration errors; `Test rule` verifies end to end before relying on it |
 | **Silent misconfiguration reaches production unnoticed** | Access unexpectedly denied (or, for overly broad conditions, granted) at runtime | Verify issuer dry-run and live rule test catch mistakes before a real workflow depends on them |
 
@@ -369,7 +400,7 @@ status:
 ```
 
 Separating issuer trust from match conditions means one TrustedIssuer backs
-every project's WorkloadIdentityPoolRules for that platform — JWKS
+every project's WorkloadIdentityRules for that platform — JWKS
 configuration is fetched, verified, and rotated once, centrally, instead of
 once per project per attribute condition.
 
@@ -377,7 +408,7 @@ once per project per attribute condition.
 
 Groups related issuers and rules within a project and provides a common point
 of control (e.g., emergency disable). Omit `poolRef` on
-WorkloadIdentityPoolIssuer or WorkloadIdentityPoolRule to use the project's
+WorkloadIdentityIssuer or WorkloadIdentityRule to use the project's
 implicit `default` pool instead of creating one explicitly.
 
 ```yaml
@@ -397,18 +428,16 @@ status:
       status: "True"
 ```
 
-#### WorkloadIdentityPoolIssuer
+#### WorkloadIdentityIssuer
 
-Enables a TrustedIssuer for use within a project's pool. Holds no trust
-configuration of its own in v1 — issuer identity and JWKS come entirely from
-the referenced TrustedIssuer. This indirection is what lets a project
-participate in a platform-level issuer without redeclaring its configuration,
-and leaves room for project-scoped custom issuers (see [Future
-Work](#future-work)) to slot into the same shape later.
+Either enables a TrustedIssuer for use within a project's pool, or registers a
+project-owned custom OIDC issuer directly. `spec` accepts exactly one of
+`trustedIssuerRef` or `oidc` — never both:
 
 ```yaml
+# Enable a platform-managed TrustedIssuer
 apiVersion: iam.miloapis.com/v1alpha1
-kind: WorkloadIdentityPoolIssuer
+kind: WorkloadIdentityIssuer
 metadata:
   name: github-actions
 spec:
@@ -422,9 +451,38 @@ status:
       status: "True"
 ```
 
-#### WorkloadIdentityPoolRule
+```yaml
+# Register a project-owned custom issuer instead
+apiVersion: iam.miloapis.com/v1alpha1
+kind: WorkloadIdentityIssuer
+metadata:
+  name: internal-spire
+spec:
+  poolRef:
+    name: ci-cd-pool
+  oidc:
+    issuerUri: "https://spire.internal.acme-corp.com"
+    jwks:
+      source: inline  # discovery | explicitUrl | inline
+      inline: "<JWKS document, base64-encoded>"
+status:
+  conditions:
+    - type: Verified      # set by the Verify issuer dry-run
+      status: "True"
+    - type: Ready
+      status: "True"
+```
 
-Matches tokens from a WorkloadIdentityPoolIssuer against audience, claim, and
+A custom issuer is scoped to the project that registers it and cannot be
+referenced from other projects — that scoping, plus the same URL constraints
+and Verify-issuer dry-run applied to TrustedIssuer, is what makes opening this
+up to project owners safe from v1 rather than deferring it. See [Custom
+Issuers Go Through the Same Verification
+Path](#custom-issuers-go-through-the-same-verification-path).
+
+#### WorkloadIdentityRule
+
+Matches tokens from a WorkloadIdentityIssuer against audience, claim, and
 attribute conditions, and defines the resulting principal's attribute mapping.
 Multiple rules can reference the same issuer, each with independent match
 conditions and audiences — this is how the [Restrict Access by
@@ -433,7 +491,7 @@ configuration per branch policy.
 
 ```yaml
 apiVersion: iam.miloapis.com/v1alpha1
-kind: WorkloadIdentityPoolRule
+kind: WorkloadIdentityRule
 metadata:
   name: github-actions-main
 spec:
@@ -472,7 +530,7 @@ status:
 
 Hand-typing a principal URI into a PolicyBinding's `subjects` list is
 error-prone — a typo silently produces a binding that never matches. Instead,
-`PolicyBinding` accepts a typed reference to a `WorkloadIdentityPoolRule` as
+`PolicyBinding` accepts a typed reference to a `WorkloadIdentityRule` as
 sugar for the URI:
 
 ```yaml
@@ -484,7 +542,7 @@ spec:
   roleRef:
     name: project-editor
   subjects:
-    - kind: WorkloadIdentityPoolRule
+    - kind: WorkloadIdentityRule
       name: github-actions-main
   resourceSelector:
     resourceKind:
@@ -494,7 +552,7 @@ spec:
 
 This is not new coupling: `PolicyBinding` already resolves typed subject
 references for `User` and `ServiceAccount` into the identifier stored as the
-OpenFGA subject tuple. Adding `WorkloadIdentityPoolRule` is one more entry in
+OpenFGA subject tuple. Adding `WorkloadIdentityRule` is one more entry in
 that existing resolution path, not a new mechanism.
 
 Resolution is a compiled registry (`GroupKind` → subject template), not a
@@ -513,15 +571,15 @@ Observability](#verification-and-observability) exists as a separate check.
 
 ### Verification and Observability
 
-A WorkloadIdentityPoolIssuer or WorkloadIdentityPoolRule can be syntactically
+A WorkloadIdentityIssuer or WorkloadIdentityRule can be syntactically
 valid yet never match a real token (wrong audience, a typo in an attribute
 condition, an unreachable JWKS endpoint). The console gives project owners two
 pre-flight checks and one ongoing view:
 
 | Feature | What it does | Where it surfaces |
 |---|---|---|
-| **Verify issuer** | Dry-run: fetches and parses the JWKS from the configured source, without creating or modifying anything. Available on WorkloadIdentityPoolIssuer and, for platform admins, on TrustedIssuer. | `Verified` condition in `status.conditions` |
-| **Test rule** | Opens a 15-minute live window on a WorkloadIdentityPoolRule. Trigger a real exchange (a CI run, a manual `datumctl` federated login) within the window and the console reports success or the specific failure reason (signature invalid, audience mismatch, condition not satisfied) in real time. Re-runnable anytime from the rule's detail page if the window elapses unused. | `status.testWindow.expiresAt`, `Verified` condition |
+| **Verify issuer** | Dry-run: fetches and parses the JWKS from the configured source, without creating or modifying anything. Available on WorkloadIdentityIssuer and, for platform admins, on TrustedIssuer. | `Verified` condition in `status.conditions` |
+| **Test rule** | Opens a 15-minute live window on a WorkloadIdentityRule. Trigger a real exchange (a CI run, a manual `datumctl` federated login) within the window and the console reports success or the specific failure reason (signature invalid, audience mismatch, condition not satisfied) in real time. Re-runnable anytime from the rule's detail page if the window elapses unused. | `status.testWindow.expiresAt`, `Verified` condition |
 | **Authentication history** | Per-rule (and per-issuer, per-pool) log of every authentication *attempt*, success or failure — distinct from the Activity timeline ([Audit CI/CD Activity](#audit-cicd-activity)), which only records actions by an *already-authenticated* principal and so never sees a failed exchange. Lets a project owner tell "never tried" from "tried and was rejected," and spot a rule under sustained failed attempts (key rotation, claim drift, or misuse). | Rule detail page, `status.lastAuthenticationTime` |
 
 ### Authentication Flow
@@ -562,7 +620,7 @@ pre-flight checks and one ongoing view:
 ### Authorization Integration
 
 Federated identities become subjects in PolicyBindings, either as a typed
-`WorkloadIdentityPoolRule` reference (see [Subject
+`WorkloadIdentityRule` reference (see [Subject
 Resolution](#subject-resolution), the recommended form) or as the raw
 principal URI string it resolves to:
 
@@ -621,14 +679,6 @@ expand based on customer feedback:
 - Requires OpenFGA integration design
 - Enables different permissions based on attributes without multiple rules
 
-**Project-defined custom issuers:**
-
-- Let project owners register a WorkloadIdentityPoolIssuer with its own
-  `issuerUri`/JWKS instead of only referencing a platform TrustedIssuer
-- Lifts the v1 restriction to platform-vetted issuers; requires the security
-  guardrails called out in the original Non-Goals (audience/subject
-  constraints, reachability requirements) before it's safe to open up
-
 **Organization-level pools:**
 
 - Shared pools across projects within an organization
@@ -651,7 +701,7 @@ expand based on customer feedback:
 Workload Identity Federation builds on existing platform services:
 
 - **IAM**: PolicyBindings grant permissions to federated identities, and
-  resolve `WorkloadIdentityPoolRule` subject references via the [subject
+  resolve `WorkloadIdentityRule` subject references via the [subject
   resolver registry](#subject-resolution)
 - **Activity**: Successful authentication events appear in the audit timeline,
   attributed to the resulting principal

--- a/enhancements/platform/identity-and-access-management/workload-identity-federation/README.md
+++ b/enhancements/platform/identity-and-access-management/workload-identity-federation/README.md
@@ -20,6 +20,8 @@ latest-milestone: "v0.1"
   - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [Resource Model](#resource-model)
+  - [Subject Resolution](#subject-resolution)
+  - [Verification and Observability](#verification-and-observability)
   - [Authentication Flow](#authentication-flow)
   - [Authorization Integration](#authorization-integration)
   - [Attribute-Based Access Control](#attribute-based-access-control)
@@ -31,8 +33,9 @@ latest-milestone: "v0.1"
 
 Workload Identity Federation enables external platforms (GitHub Actions, GCP,
 AWS, Azure) to authenticate to Milo using their native OIDC tokens instead of
-long-lived credentials. Project owners configure trust relationships through
-WorkloadIdentityPool and WorkloadIdentityPoolProvider resources, and federated
+long-lived credentials. Platform administrators register trusted OIDC issuers,
+and project owners configure trust relationships through WorkloadIdentityPool,
+WorkloadIdentityPoolIssuer, and WorkloadIdentityPoolRule resources. Federated
 identities become subjects in PolicyBindings using principal URI strings.
 
 This approach eliminates credential management burden, removes the need to store
@@ -87,15 +90,29 @@ token. No long-lived credentials are shared or stored.
 
 ## Proposal
 
-Workload Identity Federation introduces two resources that project owners use to
-configure trust relationships with external identity providers:
+Workload Identity Federation introduces one platform-level resource and three
+project-level resources. Trust in an external OIDC issuer and the conditions
+under which a token from that issuer is accepted are configured separately,
+so a single issuer registration can back many different access levels without
+duplicating issuer configuration:
 
-- **WorkloadIdentityPool**: Groups related external identity providers
-- **WorkloadIdentityPoolProvider**: Configures a specific OIDC issuer with
-  attribute conditions
+- **TrustedIssuer** *(platform-level)*: Registers an OIDC issuer's identity
+  (issuer URL and JWKS source) as safe to federate against. Managed by
+  platform administrators. v1 ships TrustedIssuers for the platforms in
+  [Supported Platforms](#supported-platforms); project-defined custom issuers
+  are [Future Work](#future-work).
+- **WorkloadIdentityPool** *(project-level, optional)*: Groups related issuers
+  and rules for bulk enable/disable. Projects that don't need grouping can
+  omit it; ungrouped resources are placed in an implicit `default` pool so the
+  principal URI shape never changes.
+- **WorkloadIdentityPoolIssuer** *(project-level)*: Enables a TrustedIssuer
+  for use within a project's pool.
+- **WorkloadIdentityPoolRule** *(project-level)*: Matches tokens from a
+  specific issuer against audience, claim, and CEL attribute conditions, and
+  maps matching tokens to a principal URI.
 
 When an external workload presents an OIDC token, Milo validates it against
-matching providers and constructs a principal URI. This principal URI becomes a
+matching rules and constructs a principal URI. This principal URI becomes a
 subject in PolicyBindings, granting the federated identity access to project
 resources.
 
@@ -103,18 +120,24 @@ resources.
 
 **Setup (one-time):**
 
-1. Project owner creates a WorkloadIdentityPool to group related providers
-2. Project owner creates a WorkloadIdentityPoolProvider specifying the OIDC
-   issuer and attribute conditions
-3. Project owner creates a PolicyBinding granting the principal access to
-   resources
+1. Platform administrator registers a TrustedIssuer (already done for
+   supported platforms in v1)
+2. Project owner creates a WorkloadIdentityPoolIssuer enabling that
+   TrustedIssuer within the project (optionally within a named
+   WorkloadIdentityPool)
+3. Project owner creates one or more WorkloadIdentityPoolRules specifying
+   audience, claim, and attribute conditions
+4. Project owner creates a PolicyBinding granting the resulting principal
+   access to resources
+5. Project owner optionally verifies the setup end-to-end (see
+   [Verification and Observability](#verification-and-observability))
 
 **Runtime (every request):**
 
 1. External workload requests OIDC token from its platform (automatic in GitHub
    Actions)
 2. Workload calls Milo API with token in Authorization header
-3. Milo validates token against matching provider
+3. Milo validates token against matching rules for the token's issuer
 4. Milo constructs principal URI and checks PolicyBinding authorization
 5. Request proceeds with federated identity context
 
@@ -138,7 +161,7 @@ jobs:
         with:
           project: my-project
           pool: ci-cd-pool
-          provider: github-actions-main
+          rule: github-actions-main
       - run: datumctl apply -f manifests/
 ```
 
@@ -150,22 +173,38 @@ configuration required.
 As a team lead, I want to grant deploy access only to workflows running on the
 main branch, while allowing any branch to run read-only operations.
 
-**Experience:** Create two providers with different attribute conditions:
+**Experience:** Create one WorkloadIdentityPoolIssuer for GitHub Actions, then
+two WorkloadIdentityPoolRules against it with different attribute conditions:
 
 - `github-actions-main`: Condition requires `attribute.ref ==
   "refs/heads/main"` → bound to deployer role
 - `github-actions-all`: No branch restriction → bound to viewer role
 
-Workflows on feature branches can view resources but cannot deploy.
+Both rules reuse the same issuer registration — no duplicate issuer or JWKS
+configuration. Workflows on feature branches can view resources but cannot
+deploy.
+
+#### Verify a New Rule Before Relying On It
+
+As a developer, I want to confirm my WorkloadIdentityPoolRule is configured
+correctly before I point a real CI/CD pipeline at it.
+
+**Experience:** After creating the issuer and rule, select **Test rule** in
+the console. Milo listens for a live token exchange matching that rule for 15
+minutes. Trigger a workflow run (or a manual `datumctl` federated login) within
+that window; the console shows the exchange succeeding or failing in real
+time, including the specific reason for a failure (signature invalid, audience
+mismatch, condition not satisfied). If the window elapses without an attempt,
+the rule persists and the test can be re-run from the rule's detail page.
 
 #### Authenticate from GCP Cloud Functions
 
 As a developer, I want my GCP Cloud Function to call Milo APIs using its service
 identity without embedding credentials in code.
 
-**Experience:** Create a provider for the GCP issuer with a condition matching
-the service account email. The Cloud Function authenticates using its native
-identity token.
+**Experience:** Create a WorkloadIdentityPoolIssuer referencing the GCP
+TrustedIssuer, then a rule with a condition matching the service account
+email. The Cloud Function authenticates using its native identity token.
 
 #### Revoke Access Immediately
 
@@ -173,7 +212,7 @@ As a security engineer, I want to immediately revoke access for a compromised
 workflow without waiting for credential expiration.
 
 **Experience:** Delete the PolicyBinding or disable the
-WorkloadIdentityPoolProvider. Access is denied immediately on the next request,
+WorkloadIdentityPoolRule. Access is denied immediately on the next request,
 even though the OIDC token may still be valid.
 
 #### Audit CI/CD Activity
@@ -182,12 +221,16 @@ As a compliance officer, I want to see which CI/CD workflows accessed my project
 and what actions they performed.
 
 **Experience:** View the Activity timeline filtered by principal. Each action
-shows the principal URI, which encodes the pool and provider. Cross-reference
-with CI/CD logs to identify specific workflow runs.
+shows the principal URI, which encodes the pool and rule. Cross-reference with
+CI/CD logs to identify specific workflow runs. For authentication attempts
+that never resulted in an action — including failed ones — see the rule's
+Authentication History (see
+[Verification and Observability](#verification-and-observability)).
 
 ### Supported Platforms
 
-Initial support targets platforms with mature OIDC token support:
+Initial support targets platforms with mature OIDC token support. Each is
+pre-registered as a platform-level TrustedIssuer:
 
 | Platform | Issuer | Key Claims |
 |----------|--------|------------|
@@ -197,15 +240,17 @@ Initial support targets platforms with mature OIDC token support:
 | **Azure AD** | `https://login.microsoftonline.com/{tenant}/v2.0` | `sub`, `oid`, `appid` |
 
 These platforms automatically provide OIDC tokens to workloads without
-additional configuration.
+additional configuration. Project owners reference the corresponding
+TrustedIssuer from a WorkloadIdentityPoolIssuer; they do not configure issuer
+URLs or JWKS sources directly in v1.
 
 ### Security
 
 #### Trust Model
 
 - **Token validation**: Signature verified using JWKS from issuer
-- **Issuer validation**: Token's `iss` claim must match provider's configured
-  issuer
+- **Issuer validation**: Token's `iss` claim must match the TrustedIssuer's
+  configured issuer
 - **Audience validation**: Token's `aud` claim must match configured audiences
 - **Expiration**: Tokens older than 1 hour are rejected
 - **Attribute conditions**: CEL expressions evaluated before authentication
@@ -228,9 +273,10 @@ Access can be revoked through multiple mechanisms:
 | Mechanism | Effect | Latency |
 |-----------|--------|---------|
 | Delete PolicyBinding | Authorization denied | Immediate |
-| Disable provider | Authentication rejected | Immediate |
-| Delete provider | Authentication rejected | Immediate |
-| Disable pool | All providers in pool rejected | Immediate |
+| Disable rule | Authentication rejected | Immediate |
+| Delete rule | Authentication rejected | Immediate |
+| Disable issuer | Authentication rejected for all rules on that issuer | Immediate |
+| Disable pool | All issuers and rules in pool rejected | Immediate |
 
 Unlike long-lived credentials, there's no need to rotate secrets or wait for
 expiration.
@@ -239,18 +285,39 @@ expiration.
 
 #### Project Control Plane Scope
 
-WorkloadIdentityPool and WorkloadIdentityPoolProvider are cluster-scoped within
-a project's control plane. Since projects are dedicated control planes in Milo,
-these resources are naturally project-scoped without requiring namespaces.
+WorkloadIdentityPool, WorkloadIdentityPoolIssuer, and WorkloadIdentityPoolRule
+are cluster-scoped within a project's control plane. Since projects are
+dedicated control planes in Milo, these resources are naturally project-scoped
+without requiring namespaces. TrustedIssuer is the one exception: it is a
+platform-level resource managed outside any project's control plane.
+
+#### Pools Are Optional
+
+WorkloadIdentityPool exists purely for grouping and bulk enable/disable.
+WorkloadIdentityPoolIssuer and WorkloadIdentityPoolRule may omit `poolRef`
+entirely, in which case they're placed in an implicit `default` pool scoped to
+the project. This keeps the principal URI shape
+(`principal://.../pools/{pool}/rules/{rule}`) stable whether or not a project
+ever creates an explicit pool, and avoids requiring pool creation for the
+common single-issuer, single-rule case.
+
+#### Audiences Are a Rule-Level Match Condition
+
+Allowed audiences are configured per WorkloadIdentityPoolRule, not on the
+issuer. This lets two rules against the same issuer require different
+audiences (for example, a stricter audience for a deployer rule than for a
+read-only rule) without duplicating issuer configuration, and keeps audience
+validation grouped with the rest of the rule's match logic (`claims`,
+`attributeCondition`).
 
 #### Attribute Conditions at Authentication Time
 
 Attribute conditions (CEL expressions) are evaluated during authentication, not
 authorization. This means:
 
-- All tokens from a provider share the same principal URI
+- All tokens matching a rule share the same principal URI
 - To grant different permissions based on attributes (e.g., branch), create
-  separate providers
+  separate rules against the same issuer
 
 Future work may add binding-level conditions for finer-grained control.
 
@@ -267,17 +334,49 @@ ensuring key rotation is handled gracefully.
 | **Overly permissive conditions** | Unintended access granted | Conditions are required; validation rejects empty conditions |
 | **JWKS endpoint unavailable** | New tokens cannot validate | Cache last-known-good JWKS; tokens cached during outage |
 | **Token replay** | Same token reused maliciously | Short token lifetime (1 hour max); `exp` claim enforced |
-| **Issuer spoofing** | Fake tokens accepted | JWKS fetched only from configured issuer over HTTPS |
-| **Misconfigured provider** | Authentication failures | Status conditions surface configuration errors |
+| **Issuer spoofing** | Fake tokens accepted | JWKS fetched only from configured issuer over HTTPS; v1 issuers are limited to platform-vetted TrustedIssuers |
+| **Misconfigured rule** | Authentication failures | Status conditions surface configuration errors; `Test rule` verifies end to end before relying on it |
+| **Silent misconfiguration reaches production unnoticed** | Access unexpectedly denied (or, for overly broad conditions, granted) at runtime | Verify issuer dry-run and live rule test catch mistakes before a real workflow depends on them |
 
 ## Design Details
 
 ### Resource Model
 
-#### WorkloadIdentityPool
+#### TrustedIssuer *(platform-level)*
 
-Groups related identity providers and provides a common point of control (e.g.,
-emergency disable).
+Registers an OIDC issuer's identity as safe to federate against, cluster-wide.
+Managed by platform administrators, not project owners. v1 ships a
+TrustedIssuer for each platform in [Supported Platforms](#supported-platforms).
+
+```yaml
+apiVersion: iam.miloapis.com/v1alpha1
+kind: TrustedIssuer
+metadata:
+  name: github-actions
+spec:
+  displayName: "GitHub Actions"
+  issuerUri: "https://token.actions.githubusercontent.com"
+  jwks:
+    source: discovery  # discovery | explicitUrl | inline
+status:
+  resolvedJwksUri: "https://token.actions.githubusercontent.com/.well-known/jwks"
+  conditions:
+    - type: Verified
+      status: "True"
+      lastVerifiedTime: "2026-07-10T12:00:00Z"
+```
+
+Separating issuer trust from match conditions means one TrustedIssuer backs
+every project's WorkloadIdentityPoolRules for that platform — JWKS
+configuration is fetched, verified, and rotated once, centrally, instead of
+once per project per attribute condition.
+
+#### WorkloadIdentityPool *(optional)*
+
+Groups related issuers and rules within a project and provides a common point
+of control (e.g., emergency disable). Omit `poolRef` on
+WorkloadIdentityPoolIssuer or WorkloadIdentityPoolRule to use the project's
+implicit `default` pool instead of creating one explicitly.
 
 ```yaml
 apiVersion: iam.miloapis.com/v1alpha1
@@ -289,32 +388,60 @@ spec:
   description: "Pool for CI/CD pipeline authentications"
   disabled: false  # Emergency disable switch
 status:
-  providerCount: 2
+  issuerCount: 1
+  ruleCount: 2
   conditions:
     - type: Ready
       status: "True"
 ```
 
-#### WorkloadIdentityPoolProvider
+#### WorkloadIdentityPoolIssuer
 
-Configures trust for a specific OIDC issuer with attribute mapping and
-conditions.
+Enables a TrustedIssuer for use within a project's pool. Holds no trust
+configuration of its own in v1 — issuer identity and JWKS come entirely from
+the referenced TrustedIssuer. This indirection is what lets a project
+participate in a platform-level issuer without redeclaring its configuration,
+and leaves room for project-scoped custom issuers (see [Future
+Work](#future-work)) to slot into the same shape later.
 
 ```yaml
 apiVersion: iam.miloapis.com/v1alpha1
-kind: WorkloadIdentityPoolProvider
+kind: WorkloadIdentityPoolIssuer
+metadata:
+  name: github-actions
+spec:
+  poolRef:
+    name: ci-cd-pool  # optional; omitted uses the project's default pool
+  trustedIssuerRef:
+    name: github-actions
+status:
+  conditions:
+    - type: Ready
+      status: "True"
+```
+
+#### WorkloadIdentityPoolRule
+
+Matches tokens from a WorkloadIdentityPoolIssuer against audience, claim, and
+attribute conditions, and defines the resulting principal's attribute mapping.
+Multiple rules can reference the same issuer, each with independent match
+conditions and audiences — this is how the [Restrict Access by
+Branch](#restrict-access-by-branch) story avoids duplicating issuer
+configuration per branch policy.
+
+```yaml
+apiVersion: iam.miloapis.com/v1alpha1
+kind: WorkloadIdentityPoolRule
 metadata:
   name: github-actions-main
 spec:
-  poolRef:
-    name: ci-cd-pool
+  issuerRef:
+    name: github-actions
 
   displayName: "GitHub Actions - Main Branch"
 
-  oidc:
-    issuerUri: "https://token.actions.githubusercontent.com"
-    allowedAudiences:
-      - "https://api.miloapis.com"
+  allowedAudiences:
+    - "https://api.miloapis.com"
 
   # Map token claims to attributes
   attributeMapping:
@@ -329,12 +456,71 @@ spec:
     attribute.ref == "refs/heads/main"
 
 status:
-  principalIdentifier: "principal://iam.miloapis.com/projects/my-project/pools/ci-cd-pool/providers/github-actions-main"
-  resolvedJwksUri: "https://token.actions.githubusercontent.com/.well-known/jwks"
+  principalIdentifier: "principal://iam.miloapis.com/projects/my-project/pools/ci-cd-pool/rules/github-actions-main"
   conditions:
     - type: Ready
       status: "True"
+    - type: Verified          # flips to "True" once a live test exchange succeeds
+      status: "True"
+      reason: TestExchangeSucceeded
+      lastAuthenticationTime: "2026-07-15T09:04:22Z"
 ```
+
+### Subject Resolution
+
+Hand-typing a principal URI into a PolicyBinding's `subjects` list is
+error-prone — a typo silently produces a binding that never matches. Instead,
+`PolicyBinding` accepts a typed reference to a `WorkloadIdentityPoolRule` as
+sugar for the URI:
+
+```yaml
+apiVersion: iam.miloapis.com/v1alpha1
+kind: PolicyBinding
+metadata:
+  name: github-deployer
+spec:
+  roleRef:
+    name: project-editor
+  subjects:
+    - kind: WorkloadIdentityPoolRule
+      name: github-actions-main
+  resourceSelector:
+    resourceKind:
+      apiGroup: resourcemanager.miloapis.com
+      kind: Project
+```
+
+This is not new coupling: `PolicyBinding` already resolves typed subject
+references for `User` and `ServiceAccount` into the identifier stored as the
+OpenFGA subject tuple. Adding `WorkloadIdentityPoolRule` is one more entry in
+that existing resolution path, not a new mechanism.
+
+Resolution is a compiled registry (`GroupKind` → subject template), not a
+runtime-editable policy: a misresolved subject fails *open* — it grants the
+binding to the wrong identity — where a misconfigured `attributeCondition`
+only fails *closed*, so this mapping stays code-reviewed rather than
+cluster-admin-configurable. The resolved string is also written to the
+referenced rule's `status.principalIdentifier`, so it's computed once and
+discoverable from the rule itself, whether a PolicyBinding references the rule
+directly or a user copies the URI by hand.
+
+A resolved reference validates only that the rule *exists*, not that any
+workload will ever present a token matching it — that gap is inherent to
+federated identity and is why [Verification and
+Observability](#verification-and-observability) exists as a separate check.
+
+### Verification and Observability
+
+A WorkloadIdentityPoolIssuer or WorkloadIdentityPoolRule can be syntactically
+valid yet never match a real token (wrong audience, a typo in an attribute
+condition, an unreachable JWKS endpoint). The console gives project owners two
+pre-flight checks and one ongoing view:
+
+| Feature | What it does | Where it surfaces |
+|---|---|---|
+| **Verify issuer** | Dry-run: fetches and parses the JWKS from the configured source, without creating or modifying anything. Available on WorkloadIdentityPoolIssuer and, for platform admins, on TrustedIssuer. | `Verified` condition in `status.conditions` |
+| **Test rule** | Opens a 15-minute live window on a WorkloadIdentityPoolRule. Trigger a real exchange (a CI run, a manual `datumctl` federated login) within the window and the console reports success or the specific failure reason (signature invalid, audience mismatch, condition not satisfied) in real time. Re-runnable anytime from the rule's detail page if the window elapses unused. | `status.testWindow.expiresAt`, `Verified` condition |
+| **Authentication history** | Per-rule (and per-issuer, per-pool) log of every authentication *attempt*, success or failure — distinct from the Activity timeline ([Audit CI/CD Activity](#audit-cicd-activity)), which only records actions by an *already-authenticated* principal and so never sees a failed exchange. Lets a project owner tell "never tried" from "tried and was rejected," and spot a rule under sustained failed attempts (key rotation, claim drift, or misuse). | Rule detail page, `status.lastAuthenticationTime` |
 
 ### Authentication Flow
 
@@ -354,23 +540,29 @@ status:
        │     Authorization: Bearer <jwt>  │                                     │
        │─────────────────────────────────>│                                     │
        │                                  │                                     │
-       │                                  │  4. Fetch JWKS (cached)             │
+       │                                  │  4. Fetch JWKS (cached from TrustedIssuer) │
        │                                  │────────────────────────────────────>│
        │                                  │                                     │
-       │                                  │  5. Validate signature, claims      │
-       │                                  │  6. Extract attributes              │
-       │                                  │  7. Evaluate CEL condition          │
-       │                                  │  8. Construct principal URI         │
-       │                                  │  9. Check PolicyBinding (OpenFGA)   │
+       │                                  │  5. Find rules for matching issuer  │
+       │                                  │  6. Validate signature, claims,     │
+       │                                  │     audience against each rule      │
+       │                                  │  7. Extract attributes              │
+       │                                  │  8. Evaluate CEL condition          │
+       │                                  │  9. Construct principal URI         │
+       │                                  │ 10. Check PolicyBinding (OpenFGA)   │
+       │                                  │ 11. Record authentication attempt   │
+       │                                  │     (Authentication History)        │
        │                                  │                                     │
-       │  10. API response                │                                     │
+       │  12. API response                │                                     │
        │<─────────────────────────────────│                                     │
 ```
 
 ### Authorization Integration
 
-Federated identities become subjects in PolicyBindings using principal URI
-strings:
+Federated identities become subjects in PolicyBindings, either as a typed
+`WorkloadIdentityPoolRule` reference (see [Subject
+Resolution](#subject-resolution), the recommended form) or as the raw
+principal URI string it resolves to:
 
 ```yaml
 apiVersion: iam.miloapis.com/v1alpha1
@@ -382,17 +574,19 @@ spec:
     name: project-editor
   subjects:
     - kind: Principal
-      name: "principal://iam.miloapis.com/projects/my-project/pools/ci-cd-pool/providers/github-actions-main"
+      name: "principal://iam.miloapis.com/projects/my-project/pools/ci-cd-pool/rules/github-actions-main"
   resourceSelector:
     resourceKind:
       apiGroup: resourcemanager.miloapis.com
       kind: Project
 ```
 
-The principal URI format follows GCP's proven pattern:
+The principal URI format follows GCP's proven pattern, with `rules` in place
+of GCP's `providers` since issuer trust and match conditions are separate
+resources here:
 
 ```
-principal://iam.miloapis.com/projects/{project}/pools/{pool}/providers/{provider}
+principal://iam.miloapis.com/projects/{project}/pools/{pool}/rules/{rule}
 ```
 
 Including the project in the URI ensures principals are globally unique across
@@ -411,7 +605,7 @@ authentication time:
 - **Specific actor**: `attribute.actor == "deploy-bot"`
 - **Combined**: `attribute.repository == "acme-corp/app" && attribute.ref == "refs/heads/main"`
 
-Conditions are required—providers without conditions are rejected during
+Conditions are required—rules without conditions are rejected during
 validation.
 
 ## Future Work
@@ -423,16 +617,25 @@ expand based on customer feedback:
 
 - CEL conditions on PolicyBinding subjects for finer-grained authorization
 - Requires OpenFGA integration design
-- Enables different permissions based on attributes without multiple providers
+- Enables different permissions based on attributes without multiple rules
+
+**Project-defined custom issuers:**
+
+- Let project owners register a WorkloadIdentityPoolIssuer with its own
+  `issuerUri`/JWKS instead of only referencing a platform TrustedIssuer
+- Lifts the v1 restriction to platform-vetted issuers; requires the security
+  guardrails called out in the original Non-Goals (audience/subject
+  constraints, reachability requirements) before it's safe to open up
 
 **Organization-level pools:**
 
 - Shared pools across projects within an organization
 - Centralized trust management for platform teams
+- Partially addressed by TrustedIssuer, which already shares issuer trust
+  platform-wide; this item is about sharing pools/rules, not just issuers
 
 **Additional platforms:**
 
-- Custom OIDC providers (user-defined issuers with security guardrails)
 - Grafana and other SaaS provider integrations
 - SAML and X.509 provider types
 
@@ -445,8 +648,15 @@ expand based on customer feedback:
 
 Workload Identity Federation builds on existing platform services:
 
-- **IAM**: PolicyBindings grant permissions to federated identities
-- **Activity**: Authentication events appear in audit timeline
+- **IAM**: PolicyBindings grant permissions to federated identities, and
+  resolve `WorkloadIdentityPoolRule` subject references via the [subject
+  resolver registry](#subject-resolution)
+- **Activity**: Successful authentication events appear in the audit timeline,
+  attributed to the resulting principal
+- **Authentication history**: Records every authentication *attempt* — including
+  failures, which never produce a principal and so never reach Activity — for
+  the console's [Verification and Observability](#verification-and-observability)
+  views
 - **OpenFGA**: Authorization checks use principal URIs as subjects
 
 External dependencies:
@@ -476,6 +686,37 @@ External platforms obtain tokens via OAuth client credentials flow.
 - Still requires managing client secrets
 - More complex than native OIDC token support
 - Platforms already provide OIDC tokens automatically
+
+### Coupled Issuer and Match Conditions (Single Provider Resource)
+
+Fold issuer trust (issuer URL, JWKS) and match conditions (audience, claims,
+attribute condition) into one resource per rule, as GCP's
+`WorkloadIdentityPoolProvider` does.
+
+**Rejected because:**
+
+- Two access levels against one issuer (e.g., [Restrict Access by
+  Branch](#restrict-access-by-branch)) require two full resources, each
+  redeclaring the same issuer URL and JWKS source
+- Rotating an issuer's JWKS means updating every resource that uses it,
+  instead of once
+- Anthropic's WIF ships the decoupled alternative in production: one
+  `Federation Issuer` backs many independent `Federation Rules`
+
+### Federation Rule Targets a Service Account (Anthropic Pattern)
+
+Anthropic's federation rules target a pre-provisioned service account; the
+minted token carries that account's workspace role, the same authorization
+surface as a static API key.
+
+**Rejected because:**
+
+- Requires an account object per access level, reintroducing the
+  per-consumer credential proliferation this enhancement exists to avoid
+- Coarser-grained than `PolicyBinding` + principal URI, which already scopes
+  access to a single Project
+- Gains nothing authorization-wise: both a service account and a principal
+  URI are just subjects a `PolicyBinding` can reference
 
 ### Service Mesh / SPIFFE
 

--- a/enhancements/platform/identity-and-access-management/workload-identity-federation/README.md
+++ b/enhancements/platform/identity-and-access-management/workload-identity-federation/README.md
@@ -33,10 +33,12 @@ latest-milestone: "v0.1"
 
 Workload Identity Federation enables external platforms (GitHub Actions, GCP,
 AWS, Azure) to authenticate to Milo using their native OIDC tokens instead of
-long-lived credentials. Platform administrators register trusted OIDC issuers,
-and project owners configure trust relationships through WorkloadIdentityPool,
-WorkloadIdentityPoolIssuer, and WorkloadIdentityPoolRule resources. Federated
-identities become subjects in PolicyBindings using principal URI strings.
+long-lived credentials. Platform administrators register trusted OIDC issuers
+once, centrally. Project owners enable one of those issuers within their
+project and define WorkloadIdentityPoolRules that match specific tokens —
+by audience, claims, or CEL attribute conditions — to a federated identity.
+Federated identities become subjects in PolicyBindings using principal URI
+strings.
 
 This approach eliminates credential management burden, removes the need to store
 secrets in CI/CD systems, and provides automatic token expiration with clear

--- a/enhancements/platform/identity-and-access-management/workload-identity-federation/README.md
+++ b/enhancements/platform/identity-and-access-management/workload-identity-federation/README.md
@@ -86,12 +86,14 @@ token. No long-lived credentials are shared or stored.
 - Replacing user authentication (human users continue using existing auth)
 - Replacing [Platform Workload Identity][platform-workload-identity] for
   internal service-to-service authentication
-- Organization-level identity pools (project-scoped only for v1)
+- Organization-level sharing of project-owned custom issuers and rules
+  (project-scoped only for v1; platform-level TrustedIssuer already covers
+  cross-project sharing of vetted issuers)
 - Non-OIDC federation protocols (SAML, X.509)
 
 ## Proposal
 
-Workload Identity Federation introduces one platform-level resource and three
+Workload Identity Federation introduces one platform-level resource and two
 project-level resources. Trust in an external OIDC issuer and the conditions
 under which a token from that issuer is accepted are configured separately,
 so a single issuer registration can back many different access levels without
@@ -101,15 +103,12 @@ duplicating issuer configuration:
   (issuer URL and JWKS source) as safe to federate against, cluster-wide.
   Managed by platform administrators. v1 ships TrustedIssuers for the
   platforms in [Supported Platforms](#supported-platforms).
-- **WorkloadIdentityPool** *(project-level, optional)*: Groups related issuers
-  and rules for bulk enable/disable. Projects that don't need grouping can
-  omit it; ungrouped resources are placed in an implicit `default` pool so the
-  principal URI shape never changes.
 - **WorkloadIdentityIssuer** *(project-level)*: Enables a TrustedIssuer for
-  use within a project's pool, or registers a project-owned custom OIDC
-  issuer directly (its own issuer URL and JWKS source) for identity providers
-  the platform hasn't pre-vetted — a private Kubernetes cluster, SPIRE, Okta,
-  or any other standards-compliant issuer.
+  use within a project, or registers a project-owned custom OIDC issuer
+  directly (its own issuer URL and JWKS source) for identity providers the
+  platform hasn't pre-vetted — a private Kubernetes cluster, SPIRE, Okta, or
+  any other standards-compliant issuer. Also the unit of emergency
+  disable — disabling an issuer immediately rejects every rule under it.
 - **WorkloadIdentityRule** *(project-level)*: Matches tokens from a
   specific issuer against audience, claim, and CEL attribute conditions, and
   maps matching tokens to a principal URI.
@@ -126,8 +125,7 @@ resources.
 1. Platform administrator registers a TrustedIssuer (already done for
    supported platforms in v1)
 2. Project owner creates a WorkloadIdentityIssuer enabling that
-   TrustedIssuer within the project (optionally within a named
-   WorkloadIdentityPool)
+   TrustedIssuer within the project
 3. Project owner creates one or more WorkloadIdentityRules specifying
    audience, claim, and attribute conditions
 4. Project owner creates a PolicyBinding granting the resulting principal
@@ -160,16 +158,20 @@ jobs:
     permissions:
       id-token: write  # Request OIDC token
     steps:
-      - uses: datum-cloud/auth-action@v1
+      - name: Setup datumctl
+        uses: datum-cloud/setup-datumctl@v1
         with:
           project: my-project
-          pool: ci-cd-pool
+          issuer: github-actions
           rule: github-actions-main
       - run: datumctl apply -f manifests/
 ```
 
-The workflow authenticates using its native GitHub OIDC token. No secrets
-configuration required.
+**Setup datumctl** installs the `datumctl` CLI and configures it to
+authenticate via Workload Identity Federation in one step: it requests the
+GitHub Actions OIDC token, exchanges it against the given project/issuer/rule,
+and leaves `datumctl` ready to use for the rest of the job — no separate auth
+step, and no secrets configuration required.
 
 #### Restrict Access by Branch
 
@@ -237,7 +239,7 @@ As a compliance officer, I want to see which CI/CD workflows accessed my project
 and what actions they performed.
 
 **Experience:** View the Activity timeline filtered by principal. Each action
-shows the principal URI, which encodes the pool and rule. Cross-reference with
+shows the principal URI, which encodes the issuer and rule. Cross-reference with
 CI/CD logs to identify specific workflow runs. For authentication attempts
 that never resulted in an action — including failed ones — see the rule's
 Authentication History (see
@@ -295,8 +297,10 @@ Access can be revoked through multiple mechanisms:
 | Delete PolicyBinding | Authorization denied | Immediate |
 | Disable rule | Authentication rejected | Immediate |
 | Delete rule | Authentication rejected | Immediate |
-| Disable issuer | Authentication rejected for all rules on that issuer | Immediate |
-| Disable pool | All issuers and rules in pool rejected | Immediate |
+| Disable issuer | Authentication rejected for every rule on that issuer | Immediate |
+
+Disabling an issuer is the emergency kill switch: it's the coarsest-grained
+control available and takes effect without touching individual rules.
 
 Unlike long-lived credentials, there's no need to rotate secrets or wait for
 expiration.
@@ -305,21 +309,11 @@ expiration.
 
 #### Project Control Plane Scope
 
-WorkloadIdentityPool, WorkloadIdentityIssuer, and WorkloadIdentityRule
-are cluster-scoped within a project's control plane. Since projects are
-dedicated control planes in Milo, these resources are naturally project-scoped
-without requiring namespaces. TrustedIssuer is the one exception: it is a
-platform-level resource managed outside any project's control plane.
-
-#### Pools Are Optional
-
-WorkloadIdentityPool exists purely for grouping and bulk enable/disable.
-WorkloadIdentityIssuer and WorkloadIdentityRule may omit `poolRef`
-entirely, in which case they're placed in an implicit `default` pool scoped to
-the project. This keeps the principal URI shape
-(`principal://.../pools/{pool}/rules/{rule}`) stable whether or not a project
-ever creates an explicit pool, and avoids requiring pool creation for the
-common single-issuer, single-rule case.
+WorkloadIdentityIssuer and WorkloadIdentityRule are cluster-scoped within a
+project's control plane. Since projects are dedicated control planes in Milo,
+these resources are naturally project-scoped without requiring namespaces.
+TrustedIssuer is the one exception: it is a platform-level resource managed
+outside any project's control plane.
 
 #### Custom Issuers Go Through the Same Verification Path
 
@@ -399,40 +393,25 @@ status:
       lastVerifiedTime: "2026-07-10T12:00:00Z"
 ```
 
+`issuerUri` is validated unique across all TrustedIssuer objects at admission
+time — two platform-level registrations for the same real-world issuer would
+just be confusing, with no legitimate reason to have both. This constraint is
+platform-level only; project-owned custom issuers on WorkloadIdentityIssuer
+are not deduplicated, since redundant project-scoped registrations are the
+project's own resources to manage.
+
 Separating issuer trust from match conditions means one TrustedIssuer backs
 every project's WorkloadIdentityRules for that platform — JWKS
 configuration is fetched, verified, and rotated once, centrally, instead of
 once per project per attribute condition.
 
-#### WorkloadIdentityPool *(optional)*
-
-Groups related issuers and rules within a project and provides a common point
-of control (e.g., emergency disable). Omit `poolRef` on
-WorkloadIdentityIssuer or WorkloadIdentityRule to use the project's
-implicit `default` pool instead of creating one explicitly.
-
-```yaml
-apiVersion: iam.miloapis.com/v1alpha1
-kind: WorkloadIdentityPool
-metadata:
-  name: ci-cd-pool
-spec:
-  displayName: "CI/CD Workload Pool"
-  description: "Pool for CI/CD pipeline authentications"
-  disabled: false  # Emergency disable switch
-status:
-  issuerCount: 1
-  ruleCount: 2
-  conditions:
-    - type: Ready
-      status: "True"
-```
-
 #### WorkloadIdentityIssuer
 
-Either enables a TrustedIssuer for use within a project's pool, or registers a
+Either enables a TrustedIssuer for use within a project, or registers a
 project-owned custom OIDC issuer directly. `spec` accepts exactly one of
-`trustedIssuerRef` or `oidc` — never both:
+`trustedIssuerRef` or `oidc` — never both. It's also the unit of emergency
+disable: `spec.disabled` immediately rejects authentication for every rule
+that references this issuer, with no separate grouping resource required.
 
 ```yaml
 # Enable a platform-managed TrustedIssuer
@@ -441,11 +420,11 @@ kind: WorkloadIdentityIssuer
 metadata:
   name: github-actions
 spec:
-  poolRef:
-    name: ci-cd-pool  # optional; omitted uses the project's default pool
   trustedIssuerRef:
     name: github-actions
+  disabled: false  # emergency disable switch
 status:
+  ruleCount: 2
   conditions:
     - type: Ready
       status: "True"
@@ -458,13 +437,12 @@ kind: WorkloadIdentityIssuer
 metadata:
   name: internal-spire
 spec:
-  poolRef:
-    name: ci-cd-pool
   oidc:
     issuerUri: "https://spire.internal.acme-corp.com"
     jwks:
       source: inline  # discovery | explicitUrl | inline
       inline: "<JWKS document, base64-encoded>"
+  disabled: false
 status:
   conditions:
     - type: Verified      # set by the Verify issuer dry-run
@@ -479,6 +457,15 @@ and Verify-issuer dry-run applied to TrustedIssuer, is what makes opening this
 up to project owners safe from v1 rather than deferring it. See [Custom
 Issuers Go Through the Same Verification
 Path](#custom-issuers-go-through-the-same-verification-path).
+
+There's no separate pool resource grouping multiple issuers together. GCP's
+own workload identity pools support that, but its own best-practice guidance
+is one provider per pool to avoid subject collisions across providers — in
+practice, pools end up scoped to a single issuer anyway. Anthropic's
+federation has no pool concept at all. Given neither reference
+implementation's real usage supports a genuine need for cross-issuer
+grouping, disabling the issuer directly is the kill switch, and one resource
+kind is one fewer thing to reconcile.
 
 #### WorkloadIdentityRule
 
@@ -516,7 +503,7 @@ spec:
     attribute.ref == "refs/heads/main"
 
 status:
-  principalIdentifier: "principal://iam.miloapis.com/projects/my-project/pools/ci-cd-pool/rules/github-actions-main"
+  principalIdentifier: "principal://iam.miloapis.com/projects/my-project/issuers/github-actions/rules/github-actions-main"
   conditions:
     - type: Ready
       status: "True"
@@ -580,7 +567,7 @@ pre-flight checks and one ongoing view:
 |---|---|---|
 | **Verify issuer** | Dry-run: fetches and parses the JWKS from the configured source, without creating or modifying anything. Available on WorkloadIdentityIssuer and, for platform admins, on TrustedIssuer. | `Verified` condition in `status.conditions` |
 | **Test rule** | Opens a 15-minute live window on a WorkloadIdentityRule. Trigger a real exchange (a CI run, a manual `datumctl` federated login) within the window and the console reports success or the specific failure reason (signature invalid, audience mismatch, condition not satisfied) in real time. Re-runnable anytime from the rule's detail page if the window elapses unused. | `status.testWindow.expiresAt`, `Verified` condition |
-| **Authentication history** | Per-rule (and per-issuer, per-pool) log of every authentication *attempt*, success or failure — distinct from the Activity timeline ([Audit CI/CD Activity](#audit-cicd-activity)), which only records actions by an *already-authenticated* principal and so never sees a failed exchange. Lets a project owner tell "never tried" from "tried and was rejected," and spot a rule under sustained failed attempts (key rotation, claim drift, or misuse). | Rule detail page, `status.lastAuthenticationTime` |
+| **Authentication history** | Per-rule (and per-issuer) log of every authentication *attempt*, success or failure — distinct from the Activity timeline ([Audit CI/CD Activity](#audit-cicd-activity)), which only records actions by an *already-authenticated* principal and so never sees a failed exchange. Lets a project owner tell "never tried" from "tried and was rejected," and spot a rule under sustained failed attempts (key rotation, claim drift, or misuse). | Rule detail page, `status.lastAuthenticationTime` |
 
 ### Authentication Flow
 
@@ -634,19 +621,20 @@ spec:
     name: project-editor
   subjects:
     - kind: Principal
-      name: "principal://iam.miloapis.com/projects/my-project/pools/ci-cd-pool/rules/github-actions-main"
+      name: "principal://iam.miloapis.com/projects/my-project/issuers/github-actions/rules/github-actions-main"
   resourceSelector:
     resourceKind:
       apiGroup: resourcemanager.miloapis.com
       kind: Project
 ```
 
-The principal URI format follows GCP's proven pattern, with `rules` in place
-of GCP's `providers` since issuer trust and match conditions are separate
-resources here:
+The principal URI format follows GCP's proven pattern, with `issuers/rules`
+in place of GCP's `providers` since issuer trust and match conditions are
+separate resources here, and with no `pools` segment since there's no pool
+resource to encode:
 
 ```
-principal://iam.miloapis.com/projects/{project}/pools/{pool}/rules/{rule}
+principal://iam.miloapis.com/projects/{project}/issuers/{issuer}/rules/{rule}
 ```
 
 Including the project in the URI ensures principals are globally unique across
@@ -679,12 +667,15 @@ expand based on customer feedback:
 - Requires OpenFGA integration design
 - Enables different permissions based on attributes without multiple rules
 
-**Organization-level pools:**
+**Organization-level sharing of project-owned issuers and rules:**
 
-- Shared pools across projects within an organization
-- Centralized trust management for platform teams
-- Partially addressed by TrustedIssuer, which already shares issuer trust
-  platform-wide; this item is about sharing pools/rules, not just issuers
+- Let a custom issuer or rule defined in one project be referenced by others
+  within the same organization, for platform teams that want centralized
+  trust management without waiting on a platform administrator to promote it
+  to a TrustedIssuer
+- Partially addressed already: TrustedIssuer covers sharing a *vetted* issuer
+  platform-wide; this item is about sharing a project's own custom
+  issuers/rules directly
 
 **Additional platforms:**
 
@@ -694,7 +685,7 @@ expand based on customer feedback:
 **Enhanced matching:**
 
 - `principalSet://` URIs for attribute-based principal matching (GCP pattern)
-- Wildcard pool matching
+- Wildcard issuer matching
 
 ## Dependencies
 
@@ -769,6 +760,27 @@ surface as a static API key.
   access to a single Project
 - Gains nothing authorization-wise: both a service account and a principal
   URI are just subjects a `PolicyBinding` can reference
+
+### Standalone Pool Resource Grouping Multiple Issuers
+
+Introduce a `WorkloadIdentityPool` resource that issuers and rules optionally
+join via `poolRef`, providing an emergency-disable kill switch spanning
+multiple issuers (mirroring GCP's `WorkloadIdentityPool` →
+`WorkloadIdentityPoolProvider` hierarchy).
+
+**Rejected because:**
+
+- GCP's own best-practice guidance is one provider per pool, specifically to
+  avoid subject collisions across providers sharing a pool — the platform
+  that supports multi-issuer pools recommends against using them that way
+- Anthropic's federation has no pool concept at all, and doesn't seem worse
+  for it
+- An open `poolRef` (any issuer can join any pool) has no natural
+  authorization boundary — gating it would require a new permission-checked
+  "attach" admission path with no clear precedent motivating the complexity
+- Disabling a `WorkloadIdentityIssuer` directly already covers the only
+  concretely motivated kill-switch case (rejecting every rule under one
+  issuer); cross-issuer grouping was speculative, not drawn from a real story
 
 ### Service Mesh / SPIFFE
 


### PR DESCRIPTION
## Summary

Workload Identity Federation lets external platforms — GitHub Actions, GCP, AWS, and Azure — authenticate to Milo using their native OIDC tokens instead of long-lived credentials.

### The Problem

Today, teams that want CI/CD pipelines or cloud workloads to access their Milo projects must:
1. Create MachineAccounts with long-lived keys
2. Store those keys as secrets in GitHub, cloud parameter stores, etc.
3. Manually rotate and revoke credentials
4. Hope nothing leaks

This creates credential management burden, security risk from stored secrets, and audit difficulty.

### The Solution

With workload identity federation, external platforms authenticate using their **native short-lived OIDC tokens**:
- A GitHub Actions workflow uses its job token
- A GCP Cloud Function uses its service identity token
- No credentials are shared or stored

### How It Works

- **Trusted issuers, ready out of the box.** The platform pre-registers OIDC issuers for GitHub Actions, GCP, AWS, and Azure. You reference one — you don't configure issuer URLs or JWKS yourself.
- **Bring your own issuer, too.** Have an identity provider the platform hasn't pre-vetted — a private Kubernetes cluster, SPIRE, Okta? Register it directly on your own issuer instead of waiting on a platform team.
- **Rules, not resources per access level.** Want to restrict deploys to `main` while allowing read-only access from any branch? That's two lightweight rules against the same issuer, not two copies of your OIDC config. Each rule uses a CEL expression over token claims (repository, branch, actor, etc.) to decide what it matches.
- **One kill switch per issuer.** Disable an issuer and every rule under it stops authenticating immediately — no need to track down and disable rules one at a time.
- **Bind directly in PolicyBinding.** Reference a rule by name as a PolicyBinding subject — the platform resolves the underlying identity for you, so there's no URI to hand-copy or typo.

### Verifying Your Setup

Before a real pipeline depends on it:
- **Verify issuer** dry-runs your JWKS configuration and flags reachability problems immediately.
- **Test rule** opens a live 15-minute window — trigger a real token exchange from your workload and watch it succeed or fail in real time, with the specific reason (bad signature, audience mismatch, condition not met) if it doesn't.
- **Authentication history** logs every authentication attempt against a rule, successful or not — so you can tell "this workflow never tried" from "it tried and was rejected," and catch a pipeline under sustained failed attempts before it becomes an incident.

### Supported Platforms (v1)

- GitHub Actions
- GCP (Cloud Functions, Cloud Run, etc.)
- AWS (Lambda, ECS, etc.)
- Azure AD

### Security Benefits

- **No stored credentials**: OIDC tokens are short-lived and auto-provisioned
- **Immediate revocation**: Disable a rule or an issuer — or delete the PolicyBinding — for instant access removal
- **Full audit trail**: Every authentication attempt is logged, successful or not, with the matched claims
- **Attribute-based control**: Restrict by repository, branch, environment, or any OIDC claim
- **Fewer places to make a mistake**: pre-vetted issuers, direct rule references in PolicyBinding, and pre-flight verification catch misconfiguration before it reaches a real workflow

---

📄 See the full enhancement document for design details, user stories, and resource reference.

🤖 Generated with [Claude Code](https://claude.ai/code)
