### PR TITLE
Add Beard Project: DDoS detection and scrubbing

### DIFF
--- a/enhancements/networking/traffic-intelligence/ddos-scrubbing-beard.md
+++ b/enhancements/networking/traffic-intelligence/ddos-scrubbing-beard.md
@@ -1,0 +1,345 @@
+# The Beard Project: DDoS Detection and Scrubbing
+
+**Parent:** [Total Load Balancing](total-load-balancing.md)  
+**Status:** Early definition  
+**Codename:** Internal project name — not a go-to-market product name.
+
+---
+
+Named after Coach Beard — the one who operates quietly in the background, is always there when things go wrong, and who you barely notice until you need him. When an attack lands, Beard has already been watching, has already classified it, and has already started doing something about it. Nobody runs toward the chaos the way he does.
+
+> "I believe in process."
+
+DDoS mitigation is the same. The moment an attack is visible to the operator, it should already be half over.
+
+---
+
+## What Beard Does
+
+Beard is Datum Cloud's DDoS detection and scrubbing system. It continuously monitors traffic at every edge PoP, detects attack patterns using flow telemetry and inline telemetry, and applies the right mitigation at the right layer — inline scrubbing, surgical upstream filtering, or blackhole routing as a last resort.
+
+The primary goal is **cleaned traffic delivery**: legitimate traffic reaches the customer's application even during an active attack. Blackholing a destination is always available but is a last resort — it ends the attack by ending the service, which is rarely what a customer wants.
+
+---
+
+## Architecture
+
+Datum's anycast network is the structural advantage here. Attack traffic is naturally distributed across PoPs by BGP — no single point absorbs the full volume. Datum's anycast architecture makes inline scrubbing the preferred mitigation model for the majority of attacks, minimizing diversion complexity and avoiding centralized bottlenecks. Traffic arrives at the nearest PoP, is cleaned there, and flows directly to the next layer. No GRE tunnels, no scrubbing center RTT, no re-injection complexity.
+
+```
+                      ┌────────────────────────────┐
+                      │      Internet Traffic      │
+                      │   Legitimate + Attack Flow │
+                      └─────────────┬──────────────┘
+                                    │
+                                    │  anycast — attack volume
+                                    │  distributed across PoPs
+                                    │
+                    ┌───────────────┼───────────────┐
+                    │               │               │
+                    ▼               ▼               ▼
+             ┌──────────┐    ┌──────────┐    ┌──────────┐
+             │  PoP A   │    │  PoP B   │    │  PoP C   │
+             └────┬─────┘    └────┬─────┘    └────┬─────┘
+                  │               │               │
+         ─ ─ ─ ─ ─│─ ─ per-PoP pipeline ─ ─ ─ ─ │─ ─ ─ ─
+                  │                               │
+                  ▼ (one PoP shown)               │
+    ┌─────────────────────────────────────────┐   │
+    │             Anycast Edge PoP            │   │
+    │                                         │   │
+    │  ┌──────────────┐   ┌────────────────┐  │   │
+    │  │Flow Telemetry│   │ Inline Fast    │  │   │
+    │  │sFlow/NetFlow │   │ Path           │  │   │
+    │  │IPFIX/XDP     │   │ XDP/eBPF       │  │   │
+    │  │counters      │   │                │  │   │
+    │  └──────┬───────┘   │ · SYN cookies  │  │   │
+    │         │           │ · UDP valid.   │  │   │
+    │         ▼           │ · Bogon drop   │  │   │
+    │  ┌──────────────┐   │ · IP repute.   │  │   │
+    │  │  FastNetMon  │   │ · PPS / BPS    │  │   │
+    │  │  Detection   │   │   rate limit   │  │   │
+    │  └──────┬───────┘   └───────┬────────┘  │   │
+    │         │                   │           │   │
+    │         └─────────┬─────────┘           │   │
+    │                   ▼                     │   │
+    │       ┌───────────────────────┐         │   │
+    │       │  Mitigation Control  │         │   │
+    │       │       Plane          │         │   │
+    │       │                      │         │   │
+    │       │ · Classify attack    │         │   │
+    │       │ · Select mode        │         │   │
+    │       │ · Generate rules     │         │   │
+    │       │ · Publish signals    │◄────────┘   │
+    │       └──────────┬───────────┘             │
+    │                  │                         │
+    │       ┌──────────┼──────────┐              │
+    │       │          │          │              │
+    │       ▼          ▼          ▼              │
+    │  ┌─────────┐ ┌────────┐ ┌───────┐         │
+    │  │  GoBGP  │ │XDP/eBPF│ │ RTBH  │         │
+    │  │FlowSpec │ │ Maps   │ │(last  │         │
+    │  │upstream │ │inline  │ │resort)│         │
+    │  │surgical │ │scrub   │ └───┬───┘         │
+    │  └────┬────┘ └────┬───┘     │             │
+    │       │           │         │             │
+    └───────┼───────────┼─────────┼─────────────┘
+            │           │         │
+            ▼           ▼         ▼
+       upstream    ┌─────────┐  upstream
+       peers drop  │ Cleaned │  null-route
+       attack      │ Traffic │  destination
+       patterns    │         │
+                   │ Envoy   │
+                   │ L4 / App│
+                   └─────────┘
+```
+
+Beard's effectiveness is bounded by the available ingress, transit, and compute capacity of the Datum edge. Anycast distribution and inline mitigation dramatically increase the volume the platform can absorb, but sufficiently large attacks may still require traffic engineering, upstream cooperation, or destination blackholing.
+
+---
+
+## Mitigation Modes
+
+Beard selects the mitigation mode based on attack type, volume, and impact. Modes are not mutually exclusive — a large attack may use all three simultaneously at different layers.
+
+### Mode 1: Inline Scrubbing (Primary)
+
+XDP/eBPF programs run in the kernel fast path on each edge node, processing packets before they enter the networking stack. Rules are loaded into eBPF maps and updated dynamically by the mitigation control plane as attack signatures evolve. Enforcement is per-PoP, operating independently at each anycast ingress point.
+
+| Technique | What it stops |
+|---|---|
+| SYN cookie proxying | SYN flood — validates TCP handshake before forwarding |
+| UDP source validation | UDP reflection/amplification — drops spoofed-source UDP |
+| Bogon filtering | Packets from invalid or reserved source addresses |
+| IP reputation lookup | Known attack sources from Roy Kent lists and platform threat intel |
+| PPS / BPS rate limiting | Volumetric floods — limits per-source and per-destination |
+| Protocol validation | Malformed packets, invalid flag combinations, oversized fragments |
+| Geo-based filtering | Drops from specific countries/regions per customer sovereignty or attack-origin policy |
+
+Cleaned traffic passes directly to Envoy / L4 within the same PoP. No redirection, no tunneling, no added latency.
+
+### Mode 2: BGP FlowSpec (Surgical Upstream)
+
+GoBGP announces BGP FlowSpec rules (RFC 8955) to upstream transit peers and peering partners. FlowSpec encodes flow-matching conditions (source prefix, destination prefix, protocol, port, packet length, DSCP) and an associated action (discard, rate-limit, redirect, mark).
+
+FlowSpec is the right tool when attack traffic can be identified by a stable pattern that doesn't overlap with legitimate traffic — a specific source prefix, a specific protocol/port combination, an anomalous packet size. The rules propagate to upstream routers and drop matching traffic before it consumes PoP ingress capacity.
+
+FlowSpec rules are generated by the mitigation control plane and withdrawn automatically when the attack signature clears. Rule lifecycle is managed by GoBGP; the control plane does not manage BGP sessions directly.
+
+### Mode 3: RTBH — Remotely Triggered Black Hole (Last Resort)
+
+When a destination prefix is receiving more attack traffic than the platform can clean, and the attack is crowding out legitimate capacity, GoBGP announces a BGP community-tagged route that instructs upstream peers to null-route all traffic to the destination.
+
+RTBH preserves platform stability by sacrificing reachability to the targeted destination. It is the option of last resort and requires either explicit customer opt-in or a platform-defined threshold policy. Customers can configure:
+
+- Whether RTBH is ever permitted for their prefixes
+- At what attack volume it is triggered automatically (if at all)
+- Notification requirements before or concurrent with activation
+
+RTBH announcements are time-bounded. The control plane sets an expiry and monitors for attack cessation, withdrawing the announcement and restoring service as soon as conditions allow.
+
+---
+
+## Detection: FastNetMon
+
+FastNetMon monitors flow telemetry (sFlow, NetFlow, IPFIX) and XDP-derived counters from every edge node. It classifies attack patterns and generates alerts that the mitigation control plane acts on.
+
+### What FastNetMon Detects
+
+| Attack Class | Detection Signal |
+|---|---|
+| Volumetric (flood) | PPS and BPS thresholds per destination prefix |
+| TCP SYN flood | SYN rate vs SYN-ACK rate anomaly |
+| UDP reflection/amplification | UDP packet size distribution, response-to-request ratio |
+| ICMP flood | ICMP PPS threshold |
+| Protocol anomaly | Packet size distribution, flag pattern anomaly |
+| Slowloris / low-and-slow | Connection rate vs completion rate — sourced from Coraza via Zava |
+| HTTP flood | Request rate anomalies, repeated patterns — sourced from Coraza via Zava |
+
+Detection thresholds have two levels: **Warning** (elevated monitoring, prepare mitigation) and **Attack** (active mitigation triggered). Both thresholds are configurable per customer and per protected prefix.
+
+### Adaptive Baselines
+
+FastNetMon Advanced (the commercial version) supports automatic threshold learning — it builds per-prefix traffic baselines from historical pps, bps, and flow data and derives detection thresholds from observed normal patterns. Fixed thresholds require manual tuning and produce false positives on traffic with natural volume spikes; baseline-derived thresholds adapt to each customer's actual traffic profile.
+
+The open source version of FastNetMon supports fixed thresholds only. FastNetMon Advanced is required for adaptive baseline support — this informs the licensing decision (see Open Questions).
+
+The baseline learning window is configurable. Until a stable baseline is established for a new customer or prefix, detection operates at conservative fixed thresholds with higher false-negative tolerance. Operators should set expectations with new customers about a profiling window before adaptive detection reaches full accuracy.
+
+### Telemetry Sources
+
+| Source | Layer | Granularity | Latency |
+|---|---|---|---|
+| sFlow / NetFlow / IPFIX | L3/L4 | Sampled — 1:N packets | 10–30s typical |
+| XDP counters | L3/L4 | All packets, per-rule hit counts | Sub-second |
+| eBPF ring buffer | L3/L4 | Per-packet metadata for classified flows | Sub-second |
+| Coraza (via Zava) | L7 | Per-request rule matches, rate counters | Sub-second |
+
+XDP-derived telemetry closes the detection gap for short-burst attacks that sampling misses. Coraza adds the L7 visibility that flow telemetry cannot provide.
+
+---
+
+## Signal Integration: Higgins Bus
+
+Active attack state is a platform signal that other systems need. A PoP under active attack should influence GSLB, L4, and L7 routing decisions — traffic can be steered away from a PoP absorbing a large attack, or rate limits can be tightened automatically without waiting for operator intervention.
+
+| Track | Publisher | Consumers | Object content |
+|---|---|---|---|
+| `platform/ddos/pop/{pop-id}` | Beard control plane | GSLB, Total Load Balancing, Ops | Attack state, attack class, intensity (bps/pps), active mitigation mode, affected prefixes |
+| `org/{org-id}/ddos/{prefix}` | Beard control plane | Customer systems, alerting | Per-prefix attack state, mitigation mode, estimated traffic impact |
+
+**Consumer behavior examples:**
+
+- **GSLB** subscribes to `platform/ddos/pop/{pop-id}` — when a PoP is under a large volumetric attack it cannot fully absorb, GSLB deprioritizes that PoP in DNS answers and routes new sessions to less-affected PoPs
+- **Total Load Balancing** adjusts routing signals for the affected PoP — the health signal contribution from a PoP under attack is interpreted in attack context, not as infrastructure failure
+- **Customer alerting** subscribes to `org/{org-id}/ddos/{prefix}` — receives real-time notification of attacks against their prefixes, current mitigation mode, and estimated impact
+
+---
+
+## Relationship to Zava and Coraza
+
+L7 attack detection and enforcement is Zava's responsibility. Beard handles L3/L4; Zava handles the application layer. The two systems share signals through Higgins Bus and act on their respective layers in coordination.
+
+**Coraza** is the WAF layer running as a WebAssembly filter inside Envoy. It implements the OWASP ModSecurity Core Rule Set and inspects HTTP/HTTPS traffic inline. For DDoS purposes, Coraza's role is:
+
+- **HTTP flood detection** — identifies request rate anomalies, repeated patterns, and malformed HTTP that characterise application-layer floods
+- **Slowloris / slow-read detection** — connection hold patterns that consume server resources without generating volume detectable by flow telemetry
+- **Signature-based blocking** — OWASP CRS rules block common attack tool fingerprints and payload patterns
+- **Rate limiting enforcement** — Envoy's `local_ratelimit` and `ratelimit` filters act on signals Coraza surfaces, throttling or blocking attacking sources at the HTTP layer
+
+**Signal flow between Beard and Zava:**
+
+```
+Coraza (Envoy WASM filter)
+    │
+    │ L7 attack signals — source IP, attack class,
+    │ request rate, rule match counts
+    ▼
+Beard Mitigation Control Plane
+    │
+    ├─ Escalate to L3/L4: if L7 attack source IPs
+    │  are generating volume, add to XDP block map
+    │
+    └─ Coordinate rate limits: signal Zava to tighten
+       per-source rate limits below L7 attack threshold
+```
+
+When Coraza identifies a source IP generating HTTP flood traffic, Beard's control plane can escalate that signal to the XDP layer — blocking the IP at L3 before its packets even reach Envoy. This cross-layer escalation is more efficient than L7-only enforcement under sustained application-layer floods.
+
+**L7 detection summary:**
+
+| Attack Type | Detection | Enforcement |
+|---|---|---|
+| HTTP flood | Coraza / Envoy rate counters | Envoy `ratelimit` filter + XDP escalation |
+| Slowloris | Coraza connection tracking | Envoy connection timeout tuning + source block |
+| Malformed HTTP | Coraza CRS rules | Envoy drops connection |
+| Bot / scraper | Coraza CRS + user-agent rules | Envoy block; future JS challenge |
+| Credential stuffing | Coraza login endpoint rules | Envoy block + alerting |
+
+---
+
+## Relationship to Roy Kent
+
+Roy Kent's GeoDB and named IP lists are direct inputs to Beard's inline scrubbing layer:
+
+- **Geo filtering** — Beard's XDP programs perform geo lookups against the PoP-local Roy Kent GeoDB replica. A customer whose service has no legitimate users in a particular country can configure a geo block that Beard enforces at the XDP layer during normal operation and tightens automatically during an attack
+- **Named IP lists** — customer-curated block lists (`org/{org-id}/lists/{list-id}`) distributed via Higgins Bus feed directly into XDP eBPF maps. A customer can add a newly identified attack source range to their block list and have it enforced at every PoP within seconds
+- **Threat intel lists** — Datum-managed lists of known attack infrastructure (botnet C2, amplification reflectors, anonymizing proxies) are distributed the same way and applied across all customers
+
+---
+
+## Customer Configuration
+
+```yaml
+apiVersion: networking.datum.net/v1alpha
+kind: DDoSProtectionPolicy
+metadata:
+  name: acme-ddos-policy
+  namespace: acme-corp
+spec:
+  targetRef:
+    kind: Zone                    # or IPPrefix
+    name: acme-corp-prefixes
+  mode: auto                      # auto | scrub-only | off
+  scrubbing:
+    synCookies: true
+    udpValidation: true
+    ipReputation: true
+    geoFiltering:
+      enabled: false              # customer enables; configured via GeoSteeringPolicy
+  detection:
+    sensitivity: medium           # low | medium | high
+    customThresholds:
+      ppsWarning: 500000
+      ppsAttack: 2000000
+      bpsWarning: 1000000000      # 1 Gbps
+      bpsAttack: 5000000000       # 5 Gbps
+  rtbh:
+    permitted: true               # customer opts in to RTBH as last resort
+    autoTriggerThreshold: 20Gbps  # trigger automatically above this volume
+    requireNotification: true     # notify before triggering if possible
+  notifications:
+    onAttackStart: true
+    onMitigationChange: true
+    onAttackEnd: true
+```
+
+### What the Customer Controls vs What Datum Manages
+
+| | Customer configures | Datum manages |
+|---|---|---|
+| Protection mode | `spec.mode` | Platform-wide baseline protection always active |
+| Scrubbing techniques | Enable/disable per technique | Technique implementation, threshold tuning |
+| Detection sensitivity | `spec.detection.sensitivity` | FastNetMon infrastructure, telemetry collection |
+| Custom thresholds | `spec.detection.customThresholds` | Default thresholds based on traffic baseline |
+| RTBH opt-in | `spec.rtbh.permitted` | BGP session management, announcement lifecycle |
+| RTBH auto-trigger level | `spec.rtbh.autoTriggerThreshold` | — |
+| Notifications | `spec.notifications` | Delivery via platform alerting pipeline |
+| Block lists | Named IP lists (Roy Kent) | Datum-managed threat intel lists |
+| Geo filtering rules | Via `GeoSteeringPolicy` | PoP-local GeoDB and enforcement |
+
+### Status
+
+```yaml
+status:
+  currentState: under-attack      # clean | elevated | under-attack | mitigating | blackholed
+  activeAttacks:
+    - prefix: 203.0.113.0/24
+      class: udp-amplification
+      intensity:
+        bps: 12400000000          # 12.4 Gbps
+        pps: 8200000
+      mitigationMode: inline-scrub
+      scrubEfficiency: 0.94       # 94% of attack traffic dropped
+      startTime: "2026-06-04T09:12:00Z"
+  affectedPoPs:
+    - id: us-east-1
+      state: mitigating
+    - id: eu-west-1
+      state: clean
+```
+
+---
+
+## Open Questions
+
+- **Customer isolation: detection namespacing.** FastNetMon tracks thresholds and baselines per prefix. Are those strictly namespaced per customer so that a large attack against one customer does not skew detection thresholds or consume baseline learning budget for another? How is per-customer prefix ownership enforced in the detection layer?
+
+- **Customer isolation: XDP rule scoping.** When mitigation rules are pushed to XDP/eBPF maps in response to an attack against Customer A, are those rules strictly scoped to Customer A's prefixes? Could an overly broad drop or rate-limit rule affect Customer B's traffic landing at the same PoP?
+
+- **Customer isolation: FlowSpec blast radius.** BGP FlowSpec rules propagate to upstream peers and are network-wide in effect. A FlowSpec rule targeting an attack against Customer A's prefix could affect Customer B if they share upstream paths, transit providers, or address space in the same aggregate. How are FlowSpec rules scoped to prevent collateral impact, and what is the review process before a rule is announced?
+
+- **Customer isolation: RTBH blast radius.** A blackhole announcement for Customer A's destination prefix must not collaterally affect Customer B. What controls ensure RTBH announcements are scoped to the correct prefix length and do not aggregate into broader blocks that overlap other customers?
+
+- **Customer isolation: resource contention.** XDP/eBPF map space, BGP FlowSpec rule table capacity, and mitigation control plane processing are shared resources at each PoP. Can a sustained large attack against one customer exhaust these resources and degrade protection availability for other customers on the same PoP? What quotas or isolation boundaries apply?
+
+- **Customer isolation: visibility.** Customers subscribe to `org/{org-id}/ddos/{prefix}` for their own attack state. What ensures a customer cannot subscribe to — or infer — another customer's attack state, attack volume, or mitigation mode? This applies both to Higgins Bus subscription authorization and to any portal or API surface that exposes attack telemetry.
+
+- **Baseline profiling.** Accurate detection requires a traffic baseline per protected prefix. How is the baseline established for new customers? How long does profiling take, and what happens during the profiling window?
+- **Multi-vector attack handling.** Large attacks frequently combine multiple vectors simultaneously (volumetric + protocol + application layer). The mitigation control plane needs to classify and respond to each vector independently. How are conflicting mitigation actions across vectors resolved?
+- **L7 attack visibility.** Resolved — Beard relies on Zava (Envoy + Coraza) for L7 detection and enforcement. See Relationship to Zava and Coraza section.
+- **Scrub efficiency reporting.** Customers will want to know how much attack traffic was dropped vs passed. What is the measurement methodology and how is it surfaced — in the status subresource, in metrics, or both?
+- **Cross-PoP attack coordination.** A large distributed attack may partially overwhelm multiple PoPs simultaneously. Should the mitigation control plane coordinate across PoPs to adjust GSLB steering during an active attack, or does each PoP mitigate independently? The Higgins Bus integration covers signaling; the coordination logic needs definition.
+- **FastNetMon licensing.** FastNetMon Advanced is required — it provides adaptive baseline learning that the open-source version does not. Evaluation needed: does the per-PoP licensing model scale to Datum's PoP count, and what is the cost at full fleet scale?
+- **FlowSpec peer coverage.** BGP FlowSpec is only effective where upstream peers support it. What percentage of Datum's upstream transit and peering relationships support FlowSpec? Where it is absent, what is the fallback?

--- a/enhancements/networking/traffic-intelligence/envoy-routing-zava.md
+++ b/enhancements/networking/traffic-intelligence/envoy-routing-zava.md
@@ -62,6 +62,7 @@ Envoy is platform-managed. Customers configure Envoy behavior through Datum deli
 | 17 | Policy Driven Routing | Integration Required | `ext_proc` (external processing) filter is the integration point for Datum policy engine; sovereignty, cost, and compliance constraints evaluated externally |
 | 18 | Observability Hooks | Integration Required | Native stats, access logs, and distributed tracing built in; requires wiring to Datum's OpenTelemetry pipeline and metrics system |
 | 19 | Request Timeout Management | Native | `timeout` and `idle_timeout` per route and cluster; `max_stream_duration` for streaming workloads; `per_try_timeout` on retry policies |
+| 20 | WAF — OWASP Rule Enforcement | Integration Required | Coraza WAF runs as a WebAssembly filter inside Envoy; implements OWASP ModSecurity Core Rule Set; inspects HTTP/HTTPS inline for injection, XSS, path traversal, and application-layer DDoS patterns |
 
 ---
 
@@ -159,6 +160,28 @@ The integration work is connecting these signals to Datum's observability pipeli
 - **Routing decision context:** Where routing decisions are influenced by geo context, Nate health signals, or policy evaluation, that context should be reflected in access log fields or trace attributes so operators can understand why a request was routed to a particular upstream.
 
 **Datum systems involved:** Datum metrics pipeline (scraping or push target), Datum log ingest pipeline, Datum tracing infrastructure (OpenTelemetry collector).
+
+---
+
+### 20. WAF — Coraza
+
+[Coraza](https://coraza.io) is an open-source WAF engine that runs as a WebAssembly filter inside Envoy, inspecting HTTP/HTTPS requests and responses inline without an external sidecar or additional network hop.
+
+**What Coraza provides:**
+
+| Capability | Detail |
+|---|---|
+| OWASP CRS | ModSecurity Core Rule Set — SQL injection, XSS, path traversal, RCE, protocol anomalies |
+| Custom rules | Datum and customer-defined rules in SecLang syntax alongside the CRS |
+| Request/response inspection | Headers, body, URI — full HTTP/HTTPS payload visibility |
+| Application-layer DDoS signals | HTTP flood patterns, scanner fingerprints, malformed request sequences |
+| Audit logging | Per-request rule match events for security analysis and incident response |
+
+**Integration path:** Coraza ships as a WASM binary (`coraza-proxy-wasm`) loaded into Envoy's HTTP filter chain via the `wasm` filter. The Datum control plane distributes Coraza's rule set and configuration to each PoP via the standard xDS mechanism or as a versioned artifact via Higgins Bus (same pattern as GeoDB snapshots).
+
+**Relationship to Beard:** Coraza's rule match events and request rate counters are the L7 signal source for [Beard](ddos-scrubbing-beard.md). When Coraza identifies HTTP flood or attack tool patterns, those signals flow to Beard's mitigation control plane, which can escalate to L3/L4 enforcement at the XDP layer — blocking attacking IPs before their packets reach Envoy.
+
+**Datum systems involved:** Datum control plane (rule set distribution), Beard mitigation control plane (L7 signal consumer), Datum log ingest pipeline (Coraza audit log events).
 
 ---
 

--- a/enhancements/networking/traffic-intelligence/gslb-jamie-tartt.md
+++ b/enhancements/networking/traffic-intelligence/gslb-jamie-tartt.md
@@ -105,6 +105,8 @@ The integration path:
 
 **TTL behavior on failover:** When a PoP is removed from the answer set, clients that have already cached the old answer will continue routing to that PoP until the TTL expires. Short TTLs reduce this window but increase DNS query volume. TTL strategy needs to be defined.
 
+**DDoS-aware steering:** GSLB also subscribes to `platform/ddos/pop/{pop-id}` from [Beard](ddos-scrubbing-beard.md). When Beard reports a PoP as `mitigating` or `blackholed`, the control plane deprioritizes that PoP in DNS answers, steering new sessions to less-affected PoPs. This signal is distinct from Nate health — a PoP under active attack may show degraded health metrics without being infrastructure-failed. Treating these signals separately avoids incorrectly retiring a healthy PoP that is simply absorbing attack traffic.
+
 ---
 
 ## GeoDB Integration

--- a/enhancements/networking/traffic-intelligence/health-checks-nate.md
+++ b/enhancements/networking/traffic-intelligence/health-checks-nate.md
@@ -251,6 +251,9 @@ All probe measurements (raw latency samples, availability counts, throughput obs
 | [Galactic VPC](../research/galactic-vpc/README.md) | PoP health | Excludes degraded paths from path computation |
 | [Connectors](../connectors/initial-proposal/README.md) | Endpoint health | Reflects target health state for connector-backed upstreams |
 | Metrics / Observability | All probe measurements | Time-series retention for dashboards, alerting, capacity analysis |
+| [Beard](ddos-scrubbing-beard.md) | PoP health (context) | Distinguishes attack-induced degradation from infrastructure failure — see DDoS Context note below |
+
+**DDoS Context.** A PoP absorbing a large volumetric attack will often exhibit elevated latency, dropped probes, and reduced availability — the same signals Nate uses to mark a PoP as DEGRADED or UNHEALTHY. Consumers that act on Nate health signals (GSLB, ALB, Total Load Balancing) should correlate against Beard's `platform/ddos/pop/{pop-id}` track before concluding a PoP has failed. A PoP that is `mitigating` per Beard but `DEGRADED` per Nate is under attack, not broken — the appropriate response is DDoS-aware traffic steering, not infrastructure failover. Nate does not suppress or modify its signals during an attack; interpretation in attack context is the consumer's responsibility.
 
 ### Customer Access
 

--- a/enhancements/networking/traffic-intelligence/ip-geo-roy-kent.md
+++ b/enhancements/networking/traffic-intelligence/ip-geo-roy-kent.md
@@ -233,11 +233,23 @@ These components are hosted in UFO Compute. They each need geo context to enforc
 - Tetrate Proxy: injects geo headers into the service mesh so downstream microservices receive client context
 - WAF: applies geo-specific rule sets (e.g. stricter rules for high-risk countries, different bot thresholds by region)
 
+#### 8. Beard — DDoS Detection and Scrubbing
+
+[Beard](ddos-scrubbing-beard.md) uses geo data and named IP lists as direct inputs to its inline XDP/eBPF scrubbing layer at each PoP.
+
+- **Geo filtering:** Beard's XDP programs perform geo lookups against the PoP-local GeoDB replica. Customers can configure geo-based drop rules that Beard enforces at the XDP layer — at line rate, before packets enter the networking stack
+- **Named IP lists:** customer-curated block lists (`org/{org-id}/lists/{list-id}`) distributed via Higgins Bus are loaded directly into XDP eBPF maps. Updates propagate to enforcement within seconds of a customer write
+- **Datum threat intel lists:** Datum-managed lists of known attack infrastructure (botnet C2, amplification reflectors, anonymizing proxies) follow the same distribution path and apply across all customers
+
+- Input: client IP → geo lookup against PoP-local GeoDB; named list membership check against eBPF maps
+- Output: per-packet drop / pass decision at XDP layer
+- Key consideration: lookup must be sub-microsecond — the full GeoDB and named lists must be resident in PoP-local memory, not a remote call
+
 ---
 
 ## Distribution Architecture
 
-All seven consumers above need geo data, but they have different access patterns:
+All eight consumers above need geo data, but they have different access patterns:
 
 | Consumer | Latency need | Update tolerance | Deployment |
 |---|---|---|---|

--- a/enhancements/networking/traffic-intelligence/signal-distribution-higgins-bus.md
+++ b/enhancements/networking/traffic-intelligence/signal-distribution-higgins-bus.md
@@ -57,6 +57,19 @@ The [Nate Project](health-checks-nate.md) introduces health signals — availabi
 
 **Metrics path:** probe measurements (raw latency samples, availability counts, throughput) are also written to the Datum metrics pipeline in parallel with Higgins Bus publication. The metrics path serves dashboards and alerting; Higgins Bus serves real-time routing decisions.
 
+### The Beard Project
+
+[Beard](ddos-scrubbing-beard.md) introduces DDoS attack state as a platform signal. Two tracks carry attack information — one for platform-wide routing consumers, one for per-customer alerting.
+
+| Track | Publisher | Consumers | Object content |
+|---|---|---|---|
+| `platform/ddos/pop/{pop-id}` | Beard control plane | GSLB, Total Load Balancing, Ops | Attack state (clean / elevated / mitigating / blackholed), attack class, intensity (bps/pps), active mitigation mode, affected prefixes |
+| `org/{org-id}/ddos/{prefix}` | Beard control plane | Customer systems, alerting pipeline | Per-prefix attack state, mitigation mode, estimated traffic impact, start time |
+
+**Publish triggers:** objects are published immediately on any attack state transition and on a heartbeat interval during active attacks so consumers can detect a stalled publisher.
+
+**GSLB consumer note:** when a PoP transitions to `mitigating` or `blackholed`, GSLB deprioritizes that PoP in DNS answer sets, routing new sessions to less-affected PoPs. This is a distinct signal path from Nate health — a PoP under attack may appear degraded in Nate's health view; Beard's signal provides the attack context that distinguishes attack-induced degradation from infrastructure failure.
+
 ### Future Projects
 
 Each subsequent Total Load Balancing project extends the namespace:

--- a/enhancements/networking/traffic-intelligence/total-load-balancing-roadmap.md
+++ b/enhancements/networking/traffic-intelligence/total-load-balancing-roadmap.md
@@ -1,0 +1,91 @@
+# Total Load Balancing — Roadmap
+
+**Product area:** Deliver — Edge Delivery / Load Balancing / Fraud & Traffic Mgmt  
+**Status:** Early definition  
+**Parent:** [Total Load Balancing](total-load-balancing.md)
+
+---
+
+The roadmap is organized around four phases. The first phase is deliberately narrow: give Envoy a real-time view of UFO Compute locations and enable load balancing across them. Every subsequent phase layers signals on top of that foundation.
+
+---
+
+## Phase 1 — Envoy UFO Location Awareness
+
+Envoy (Zava) currently treats origins as static upstream clusters defined at deploy time. It has no runtime awareness of UFO Compute locations, their availability, or their capacity. This phase wires Envoy into a live UFO location registry so it can make load-balancing decisions across UFO endpoints.
+
+| # | Task | Description |
+|---|---|---|
+| 1.1 | **UFO location data model** | Define a canonical representation of a UFO location: ID, region, PoP affinity, address, and capacity tier. Stored in the platform control plane and exposed via a gRPC xDS-compatible API. |
+| 1.2 | **Envoy EDS integration** | Configure Envoy's Endpoint Discovery Service (EDS) to subscribe to UFO location updates from the control plane. Envoy receives endpoint adds, removes, and weight changes without restart. |
+| 1.3 | **UFO upstream cluster definition** | Define a named Envoy cluster (`ufo_compute`) backed by EDS. Initial policy: round-robin across all healthy UFO endpoints in the local PoP, failing over to any reachable UFO endpoint. |
+| 1.4 | **Passive outlier detection** | Configure Envoy's built-in outlier detection on the `ufo_compute` cluster — eject endpoints on consecutive 5xx, connection failures, or latency outliers. At high volume this reacts faster than probe-based checks and requires no external dependency. Nate active-check results will be layered in during Phase 2 to cover zero-traffic scenarios. |
+| 1.5 | **Locality-aware LB** | Tag EDS endpoints with Envoy `locality` (region + zone). Enable Envoy's locality-weighted load balancing so same-PoP UFO endpoints are preferred before spilling to remote PoPs. |
+| 1.6 | **Observability** | Emit per-endpoint request count, error rate, and latency from Envoy to the metrics pipeline. This becomes the baseline for all future signal-driven steering decisions. |
+
+**Exit criteria:** Envoy at any PoP can discover all UFO Compute endpoints via EDS, load balance across them with locality preference, and automatically drop unhealthy endpoints from rotation — with no manual cluster config changes.
+
+**Nate dependency note:** When the [Nate Project](health-checks-nate.md) ships, its synthetic health-check results will be fed into EDS endpoint health state to cover zero-traffic scenarios (cold UFO nodes, pre-launch regions) that passive outlier detection cannot see. This is not gated on a phase — it lands whenever Nate is ready.
+
+---
+
+## Phase 2 — Geo Signal Integration
+
+Geo signals from Roy Kent are introduced across three components in dependency order: distribution first, then the two consumers.
+
+### 2a — GeoDB Distribution
+
+Get the Roy Kent geo database reliably to every edge PoP. This is the prerequisite for all geo consumers — neither Envoy nor DNS can act on geo until the data is local.
+
+| # | Task | Description |
+|---|---|---|
+| 2.1 | **Higgins Bus geo tracks** | Publish Roy Kent geography, ASN, and IP type data as named tracks on Higgins Bus (`platform/geodb/version`, `platform/geodb/asn`, `platform/geodb/iptype`). Full database on connect, delta updates on change. |
+| 2.2 | **Local PoP cache** | Each PoP maintains a local copy of the geo database refreshed from Higgins Bus. Lookups are in-process — no round-trip to a central service on the request path. |
+| 2.3 | **Version coordination** | Track the active GeoDB version at each PoP and emit it to the metrics pipeline. Detect and alert on version skew across PoPs so stale geo data is visible before it causes routing inconsistencies. |
+
+### 2b — Geo in Envoy
+
+Use the local GeoDB for request-time enforcement and metadata enrichment at L7.
+
+| # | Task | Description |
+|---|---|---|
+| 2.4 | **Geoblocking** | Evaluate country/region block-list policies against the client's geo lookup on every inbound request. Return HTTP 403 for denied origins. DNS cannot block — Envoy is the correct enforcement point because it operates after TLS termination with full request context. |
+| 2.5 | **Request metadata enrichment** | Set `x-datum-geo-country`, `x-datum-geo-region`, `x-datum-asn`, and `x-datum-ip-type` on every request. Downstream services and WAF rules consume these headers without performing their own lookups. |
+| 2.6 | **IP type policy** | Use IP type signal (residential / datacenter / proxy / VPN / satellite) to apply differential rate limits or route to a scrubbing path before the request reaches the UFO upstream. |
+
+### 2c — Geo in DNS
+
+Use geo for PoP steering at the DNS layer — a performance decision made before any connection is established.
+
+| # | Task | Description |
+|---|---|---|
+| 2.7 | **PowerDNS GeoIP backend** | Feed Roy Kent geography into the Jamie Tartt PowerDNS GeoIP backend. DNS resolves to the nearest healthy PoP based on client country and region. |
+| 2.8 | **Health-aware GSLB hand-off** | Align DNS PoP health state with Envoy endpoint health so Jamie Tartt does not steer users to a PoP that Envoy has already marked unhealthy. |
+| 2.9 | **DDoS state in DNS** | Consume Beard attack-state signals in Jamie Tartt. Remove PoPs under active volumetric attack from DNS resolution before the attack traffic saturates the PoP's Envoy layer. |
+
+---
+
+## Phase 3 — Latency and Path Quality
+
+Add RTT, packet loss, and congestion as first-class inputs to the Envoy upstream selection decision.
+
+| # | Task | Description |
+|---|---|---|
+| 3.1 | **RTT signal collection** | Define the RTT measurement architecture (passive QUIC/TCP observation or active probing). Publish per-PoP RTT as a Higgins Bus track. |
+| 3.2 | **Envoy upstream scoring** | Extend the EDS endpoint model with a latency score derived from RTT and loss signals. Replace round-robin with a scored selection policy. |
+| 3.3 | **Congestion-aware spillover** | When a PoP's congestion signal exceeds a threshold, reduce its EDS endpoint weight rather than removing it entirely — graceful degradation. |
+| 3.4 | **Policy-over-performance** | Establish evaluation order: sovereignty constraints eliminate candidates first; latency scoring applies within compliant candidates only. |
+
+---
+
+## Phase 4 — Sovereignty, AI Routing, and Geo for Compute
+
+Add hard-constraint sovereignty enforcement, extend the decision layer to inference-bound traffic, and make geo data available to UFO Compute workloads.
+
+| # | Task | Description |
+|---|---|---|
+| 4.1 | **Sovereignty signal** | Model jurisdiction constraints as a signal (country → allowed-PoP-set). Evaluate before any latency scoring in Envoy route selection. |
+| 4.2 | **Model locality signal** | Publish which UFO compute nodes have a given inference model loaded. Add as an EDS endpoint attribute. |
+| 4.3 | **Inference routing in Envoy** | When a request carries an inference context header, filter the EDS endpoint set to nodes with the model warm before applying latency scoring. |
+| 4.4 | **GPU availability signal** | Extend the UFO location data model with GPU utilization. Apply as a weight modifier in Envoy EDS so saturated nodes receive less traffic before becoming unavailable. |
+| 4.5 | **Geo for Compute** | Make the GeoDB available to UFO Compute workloads — expose client geography, ASN, and IP type as request context so compute functions can make locality-aware decisions (e.g. data residency enforcement, personalisation, model selection) without an external lookup. Delivered via enriched request headers forwarded from Envoy (established in Phase 2b) and a local GeoDB SDK for workloads that need direct lookups. |

--- a/enhancements/networking/traffic-intelligence/total-load-balancing.md
+++ b/enhancements/networking/traffic-intelligence/total-load-balancing.md
@@ -39,14 +39,15 @@ Signals are distributed to consumers using [Higgins Bus](signal-distribution-hig
 
 ## Load Balancing Stack
 
-Datum uses a two-layer load balancing architecture. Both layers consume Total Load Balancing signals to make informed routing decisions.
+Datum uses a three-layer load balancing architecture. Every layer consumes Total Load Balancing signals to make informed routing decisions.
 
 | Layer | Technology | Customer-Configurable | Scope |
 |---|---|---|---|
+| **DNS / GSLB** | [Jamie Tartt / PowerDNS](gslb-jamie-tartt.md) | Via `GeoSteeringPolicy` | Outermost steering layer — operates before any connection is established; routes users to the right PoP based on geography, health, and DDoS state |
 | **L4 (transport)** | [Dani Rojas / Cilium](l4-load-balancing-dani-rojas.md) | For compute targets | Routes TCP/UDP traffic to UFO Compute or other customer compute; platform-managed in front of Envoy |
-| **L7 (application)** | [Zava / Envoy](envoy-routing-zava.md) | Via delivery policies | HTTP/HTTPS routing, TLS termination, origin selection, header manipulation |
+| **L7 (application)** | [Zava / Envoy](envoy-routing-zava.md) | Via delivery policies | HTTP/HTTPS routing, TLS termination, WAF (Coraza), origin selection, header manipulation |
 
-See [Dani Rojas](l4-load-balancing-dani-rojas.md) for the Cilium design, customer configuration model, and relationship to the L7 layer. See [Zava](envoy-routing-zava.md) for the full Envoy routing feature map and integration details.
+See [Jamie Tartt](gslb-jamie-tartt.md) for the GSLB design, PowerDNS GeoIP backend, and health-aware failover. See [Dani Rojas](l4-load-balancing-dani-rojas.md) for the Cilium design and customer configuration model. See [Zava](envoy-routing-zava.md) for the full Envoy routing feature map and integration details.
 
 ---
 
@@ -65,6 +66,7 @@ Total Load Balancing is built from a growing set of signals, introduced across p
 | **Congestion** | TBD | Link utilization at candidate PoPs and upstream |
 | **Sovereignty** | TBD | Data residency and legal jurisdiction rules — hard constraints on path selection |
 | **Risk** | TBD | Reputation score of source IP/ASN — feeds fraud and bot decisions |
+| **DDoS / Attack State** | [Beard](ddos-scrubbing-beard.md) | Active attack state per PoP and per customer prefix — steers traffic away from PoPs under attack |
 | **Model Locality** | TBD | Where the required inference model is currently loaded |
 | **Compute Availability** | TBD | Utilization and capacity of GPU, CPU, and DPU resources at candidate compute nodes |
 
@@ -87,7 +89,8 @@ The end state is a layered decision hierarchy applied to every traffic flow:
 | [The Roy Kent Project](ip-geo-roy-kent.md) | Geography, ASN, IP Type | In progress |
 | [The Nate Project](health-checks-nate.md) | Health (Availability, Latency, Throughput) | Early definition |
 | [Jamie Tartt](gslb-jamie-tartt.md) | GSLB / DNS — geo + health-aware PoP steering | Early definition |
-| [Zava](envoy-routing-zava.md) | L7 routing — geo, health, policy, protocol | Early definition |
+| [Dani Rojas](l4-load-balancing-dani-rojas.md) | L4 load balancing — Cilium, customer-configurable for compute targets | Early definition |
+| [Zava](envoy-routing-zava.md) | L7 routing — geo, health, WAF (Coraza), policy, protocol | Early definition |
 | [The Beard Project](ddos-scrubbing-beard.md) | DDoS detection and scrubbing — inline XDP/eBPF, BGP FlowSpec, RTBH | Early definition |
 | TBD | RTT, Packet Loss, Congestion | Not started |
 | TBD | Sovereignty, Risk | Not started |
@@ -108,6 +111,7 @@ Each Total Load Balancing project extends the track namespace:
 | RTT, Packet Loss, Congestion | TBD | TBD |
 | Sovereignty, Risk | TBD | TBD |
 | Model Locality, Compute Availability | TBD | TBD |
+| DDoS / Attack State | `platform/ddos/pop/{pop-id}`, `org/{org-id}/ddos/{prefix}` | [Beard](ddos-scrubbing-beard.md) |
 | Inference and Agent Coordination | See [Higgins Bus](signal-distribution-higgins-bus.md) — Inference and Agent Workloads namespace | TBD |
 
 Track namespaces are additive — a new signal type requires no changes to existing relay infrastructure or existing subscribers. See [Higgins Bus](signal-distribution-higgins-bus.md) for the full transport design.

--- a/enhancements/networking/traffic-intelligence/total-load-balancing.md
+++ b/enhancements/networking/traffic-intelligence/total-load-balancing.md
@@ -88,6 +88,7 @@ The end state is a layered decision hierarchy applied to every traffic flow:
 | [The Nate Project](health-checks-nate.md) | Health (Availability, Latency, Throughput) | Early definition |
 | [Jamie Tartt](gslb-jamie-tartt.md) | GSLB / DNS — geo + health-aware PoP steering | Early definition |
 | [Zava](envoy-routing-zava.md) | L7 routing — geo, health, policy, protocol | Early definition |
+| [The Beard Project](ddos-scrubbing-beard.md) | DDoS detection and scrubbing — inline XDP/eBPF, BGP FlowSpec, RTBH | Early definition |
 | TBD | RTT, Packet Loss, Congestion | Not started |
 | TBD | Sovereignty, Risk | Not started |
 | TBD | Model Locality, GPU Availability | Not started |

--- a/enhancements/networking/traffic-intelligence/total-load-balancing.md
+++ b/enhancements/networking/traffic-intelligence/total-load-balancing.md
@@ -118,6 +118,12 @@ Track namespaces are additive — a new signal type requires no changes to exist
 
 ---
 
+## Roadmap
+
+See [total-load-balancing-roadmap.md](total-load-balancing-roadmap.md) for the phased delivery plan.
+
+---
+
 ## Related Areas
 
 - **[Dani Rojas](l4-load-balancing-dani-rojas.md)** — Cilium as the transport-layer LB; customer-configurable for compute targets


### PR DESCRIPTION
## Summary

Adds the Beard Project design document and updates six existing Traffic Intelligence documents with cross-references and integration detail. Also fixes several omissions in the Total Load Balancing overview doc caught during review. Adds a dedicated roadmap document for Total Load Balancing.

Codename is internal — not a go-to-market product name.

## New Document

### [ddos-scrubbing-beard.md](enhancements/networking/traffic-intelligence/ddos-scrubbing-beard.md)

Named after Coach Beard — the one who operates quietly in the background, is always there when things go wrong, and who you barely notice until you need him.

Datum Cloud's DDoS detection and scrubbing system. The primary goal is cleaned traffic delivery — legitimate traffic reaches the customer's application even during an active attack. Blackholing is always available but is a last resort.

**Architecture**
Datum's anycast architecture makes inline scrubbing the preferred mitigation model for the majority of attacks, minimizing diversion complexity and avoiding centralized bottlenecks. Attack traffic is distributed across PoPs by BGP; each PoP scrubs inline and passes clean traffic directly to Envoy/L4 with no GRE tunnels or re-injection complexity. Beard's effectiveness is bounded by available ingress, transit, and compute capacity — sufficiently large attacks may still require traffic engineering, upstream cooperation, or destination blackholing.

**Three mitigation modes (not mutually exclusive):**
- **Inline scrubbing (primary)** — XDP/eBPF fast path: SYN cookies, UDP validation, bogon filtering, IP reputation, PPS/BPS rate limiting, protocol validation, geo-based filtering
- **BGP FlowSpec (surgical upstream)** — GoBGP announces flow-matching rules to upstream peers; drops attack patterns before they consume PoP ingress capacity; rules auto-withdrawn on attack clearance
- **RTBH (last resort)** — preserves platform stability by sacrificing reachability to the targeted destination; customer opt-in; time-bounded with auto-withdrawal

**Detection: FastNetMon Advanced**
Monitors sFlow/NetFlow/IPFIX and XDP-derived counters. XDP counters provide sub-second detection that sampling alone misses. FastNetMon Advanced (commercial) required for adaptive baseline learning. L7 attack signals (HTTP flood, slowloris) sourced from Coraza via Zava.

**Higgins Bus integration**
- `platform/ddos/pop/{pop-id}` — platform-wide attack state for GSLB steering and routing decisions
- `org/{org-id}/ddos/{prefix}` — per-customer attack state for alerting

**Customer resource: DDoSProtectionPolicy**
Configures mode (auto / scrub-only / off), scrubbing techniques, detection sensitivity, custom thresholds, RTBH opt-in and auto-trigger threshold, and notification preferences. Status subresource exposes active attacks, scrub efficiency, and per-PoP state.

**Relationships**
- Zava + Coraza: L7 detection and enforcement; Coraza signals escalate to XDP layer for cross-layer mitigation
- Roy Kent: GeoDB and named IP lists feed XDP eBPF maps directly
- Nate: attack-induced PoP degradation distinguished from infrastructure failure via correlated signals
- Jamie Tartt: GSLB subscribes to Beard attack signals to steer sessions away from PoPs under large attacks

**Open questions**
Customer isolation group (detection namespacing, XDP rule scoping, FlowSpec blast radius, RTBH blast radius, resource contention, visibility isolation), baseline profiling window, multi-vector attack handling, scrub efficiency reporting, cross-PoP coordination, FastNetMon Advanced licensing at PoP scale, FlowSpec peer coverage.

## Cross-Reference Updates

**signal-distribution-higgins-bus.md** — Beard Project track namespace added with both DDoS tracks; note distinguishing attack-induced degradation from infrastructure failure.

**ip-geo-roy-kent.md** — Beard added as consumer #8; GeoDB and named IP lists feed XDP eBPF maps for sub-microsecond per-packet enforcement; distribution architecture updated to reflect eight consumers.

**gslb-jamie-tartt.md** — DDoS-aware steering added to health-aware failover section; GSLB subscribes to Beard signals separately from Nate health to avoid incorrectly retiring a PoP absorbing an attack.

**health-checks-nate.md** — Beard added to consumers table with DDoS Context note: consumers must correlate Nate health signals with Beard attack state before triggering infrastructure failover on a PoP that is mitigating rather than failed.

**envoy-routing-zava.md** — Coraza WAF added as feature #20 in the matrix; full integration detail section covering OWASP CRS, WASM filter mechanics, rule distribution path, and the Beard signal relationship.

## Total Load Balancing Updates

### Concept doc fixes

Several omissions in the overview doc corrected in a follow-up commit:

- **Load Balancing Stack** — GSLB (Jamie Tartt / PowerDNS) added as the outermost layer; description updated from two-layer to three-layer; Zava row updated to note Coraza/WAF
- **Projects table** — Dani Rojas was missing; added between Jamie Tartt and Zava
- **Signals table** — new DDoS / Attack State row added pointing to Beard
- **Distribution Transport table** — Beard's track namespaces (`platform/ddos/pop/{pop-id}`, `org/{org-id}/ddos/{prefix}`) added

### Roadmap split into separate doc

The phased delivery plan has been extracted into [total-load-balancing-roadmap.md](enhancements/networking/traffic-intelligence/total-load-balancing-roadmap.md) and linked from the concept doc.

**Four phases:**
- **Phase 1 — Envoy UFO Location Awareness** — wire Envoy into a live UFO location registry via EDS; passive outlier detection; locality-aware LB. Self-contained, no external dependencies. Nate active checks deferred to whenever the Nate project ships, not gated on a phase.
- **Phase 2 — Geo Signal Integration** — three components in dependency order: GeoDB distribution (Higgins Bus tracks + local PoP cache), Geo in Envoy (geoblocking + request metadata enrichment), Geo in DNS (PowerDNS GeoIP + DDoS-state-aware steering).
- **Phase 3 — Latency and Path Quality** — RTT, packet loss, and congestion signals; scored upstream selection; congestion-aware spillover.
- **Phase 4 — Sovereignty, AI Routing, and Geo for Compute** — jurisdiction constraints as hard routing constraints; inference routing (model locality + GPU availability); geo data exposed to UFO Compute workloads.

## Status

Provisional — working documents, subject to change as design and implementation planning progress.