### PR TITLE
docs: add enhancement for reducing PolicyBinding tuple fan-out

### DIFF
--- a/enhancements/platform/identity-and-access-management/policybinding-tuple-fanout/README.md
+++ b/enhancements/platform/identity-and-access-management/policybinding-tuple-fanout/README.md
@@ -1,0 +1,241 @@
+---
+status: provisional
+stage: alpha
+latest-milestone: "v0.x"
+---
+
+<!-- omit from toc -->
+
+# Reduce PolicyBinding tuple fan-out
+
+Related: [datum-cloud/auth-provider-openfga](https://github.com/datum-cloud/auth-provider-openfga)
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Where the time goes](#where-the-time-goes)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [How it works today](#how-it-works-today)
+  - [The change](#the-change)
+- [Design Details](#design-details)
+  - [Authorization model](#authorization-model)
+  - [Policy reconciler](#policy-reconciler)
+  - [Migration](#migration)
+- [Risks and Mitigations](#risks-and-mitigations)
+- [Drawbacks](#drawbacks)
+- [Alternatives](#alternatives)
+- [Open Questions](#open-questions)
+- [Implementation History](#implementation-history)
+
+## Summary
+
+Every PolicyBinding is expanded into OpenFGA tuples by writing one tuple for
+each pair of (subject, permission) on the target object. A role with a handful
+of permissions is cheap. The organization owner role is not: it grants every
+permission across the whole resource hierarchy, so a single owner binding turns
+into 351 tuples.
+
+That fan-out lands on the critical path of signup. A new user cannot use their
+organization until the owner grant has propagated, and the owner grant is 351
+sequential-ish tuple writes behind a reconciler that also writes them one
+binding at a time.
+
+This proposal moves the fan-out out of the tuple data and into the
+authorization model. A binding would write a single "this subject has this role
+on this object" tuple, and the model would express which permissions that role
+grants. The model is written once; the per-binding cost drops from N tuples to
+one.
+
+## Motivation
+
+Signup latency on staging is dominated by IAM propagation, and the largest
+single contributor is the organization owner grant. We confirmed this from
+controller and OpenFGA logs across several real signups.
+
+### Where the time goes
+
+The owner binding writes 351 tuples. We saw this directly in the controller
+logs when the binding was torn down:
+
+```
+Successfully deleted tuples for PolicyBinding ... "tupleCount": 351
+```
+
+Time from user creation to the owner grant being ready, across three signups on
+the same day:
+
+| Signup      | Org owner ready | Project owner ready |
+| ----------- | --------------- | ------------------- |
+| `org-kzjnm` | +59s            | +82s                |
+| `org-tbsxl` | +25s            | +47s                |
+| `org-drc28` | +12s            | +37s                |
+
+The spread (12s to 59s for the same operation) tracks OpenFGA write latency and
+reconciler queue pressure, not anything the user did. Supporting numbers from
+the same window:
+
+- OpenFGA `Write` p99: about 990ms
+- OpenFGA `Check` p99: about 10ms (checks are not the problem)
+- `policybinding` reconcile p99: about 3.4s on a bad day, 0.9 to 1.1s on an
+  average one
+
+A smaller resource, a project owner binding, is noticeably faster because it
+carries far fewer permissions. The pattern is consistent: cost scales with the
+permission count of the bound role.
+
+### Goals
+
+- Make the number of OpenFGA tuples a PolicyBinding writes independent of how
+  many permissions its role grants.
+- Cut the time from organization creation to the owner grant being usable.
+- Keep authorization decisions identical. A Check that passes today must pass
+  after the change, and one that fails today must still fail.
+
+### Non-Goals
+
+- Changing the PolicyBinding, Role, or ProtectedResource APIs. This is an
+  internal representation change in the OpenFGA provider.
+- Changing how the portal waits for grants during onboarding. That work is
+  tracked separately.
+- Reworking the resource hierarchy or inheritance semantics.
+
+## Proposal
+
+### How it works today
+
+For each resource type the model defines one relation per permission, keyed by a
+hash of the permission name. A PolicyBinding reconciler expands the role's
+effective permissions and writes a direct tuple per permission:
+
+```
+(InternalUser:alice, hash(org.get),  Organization:org-1)
+(InternalUser:alice, hash(org.list), Organization:org-1)
+... one per permission ...
+```
+
+For the owner role that expansion is 351 rows for one subject on one object.
+
+### The change
+
+Represent the grant as role membership instead of a flattened permission list.
+A binding writes a single tuple that says "alice has role R on org-1", and the
+authorization model already knows that role R implies `org.get`, `org.list`, and
+the rest. The permission relations resolve through the role rather than through
+351 direct assignments.
+
+```
+# today: 351 tuples per owner binding
+(InternalUser:alice, hash(org.get),  Organization:org-1)
+(InternalUser:alice, hash(org.list), Organization:org-1)
+...
+
+# proposed: 1 tuple per owner binding
+(InternalUser:alice, role_<roleHash>, Organization:org-1)
+```
+
+The total amount of "which permission belongs to which role" information does
+not disappear. It moves into the authorization model, which is computed once and
+updated only when roles or protected resources change, rather than being copied
+into tuple storage on every binding.
+
+## Design Details
+
+### Authorization model
+
+Add a role-scoped relation to each resource type. For every role that can target
+a resource type, the type gains a relation such as `role_<roleHash>` that is
+directly assignable. Each existing permission relation is then defined as the
+union of its current definition and the roles that include that permission:
+
+```
+hash(org.get) = direct_assignment
+             or role_<ownerHash>       # owner includes org.get
+             or role_<viewerHash>      # viewer includes org.get
+             or tuple_to_userset(parent, hash(org.get))
+```
+
+The model grows with (roles x permissions), but it is written once by the
+authorization model reconciler and does not touch the signup path. Direct
+per-permission assignment stays supported so existing tuples keep resolving
+during migration.
+
+### Policy reconciler
+
+`buildPermissionTuples` currently emits one tuple per (subject, permission). The
+change is to emit one tuple per (subject, role) targeting the role relation,
+when the bound role is eligible for the role-based path. The diff, sibling, and
+delete logic stays the same; it simply operates over a much smaller desired set.
+
+### Migration
+
+The two representations resolve to the same Check results, so they can coexist:
+
+1. Ship the model change first, adding role relations without removing the
+   per-permission ones. No behavior change.
+2. Switch the reconciler to write role tuples for new and re-reconciled
+   bindings. Old bindings keep their permission tuples and still work.
+3. Backfill: re-reconcile existing bindings to replace permission tuples with a
+   role tuple. This is idempotent and can run in the background.
+4. Once no permission-style tuples remain for role-eligible bindings, the direct
+   per-permission assignment on permission relations can be reconsidered.
+
+Each step is independently revertible.
+
+## Risks and Mitigations
+
+The main risk is an authorization regression: a subtle difference between the
+old and new resolution paths could grant or deny something incorrectly.
+Mitigations:
+
+- Keep both representations valid at once so rollback is a reconciler flag, not a
+  data migration.
+- Add Check-equivalence tests that assert, for a representative set of subjects,
+  roles, and resources, that the role-based model returns the same decision as
+  the per-permission model.
+- Roll out on staging first and diff authorization decisions against production
+  behavior before backfilling.
+
+A secondary risk is model size. Unioning every permission over every role could
+make the model large. If that becomes a problem, scope role relations to the
+resource types a role actually targets rather than all types.
+
+## Drawbacks
+
+The authorization model becomes more complex to read, since permission relations
+now reference roles. Debugging a Check means understanding both the tuple and the
+model, where today the tuple alone tells most of the story. The migration also
+adds a period where both representations exist, which is more moving parts than a
+single cutover.
+
+## Alternatives
+
+**Batch the existing writes.** Keep the per-permission tuples but write them in
+larger OpenFGA `Write` batches. This lowers wall-clock time without changing the
+model, but the cost still scales with permission count and storage still holds
+351 rows per owner binding.
+
+**Shrink the owner role.** Grant the owner fewer permissions. This changes
+product behavior and does not address the general case of any broad role.
+
+**Precompute owner tuples at org creation.** Write the owner grant as part of
+org bootstrap rather than through a PolicyBinding. This narrows the fix to one
+role and leaves the fan-out in place for every other broad binding.
+
+## Open Questions
+
+<<[UNRESOLVED role-scoping ]>>
+Should role relations be added to every resource type, or only to the types a
+given role actually targets? The first is simpler; the second keeps the model
+smaller.
+<<[/UNRESOLVED]>>
+
+<<[UNRESOLVED groups ]>>
+Group-based subjects already resolve through `member`. Confirm the role-based
+path composes correctly with group membership so a group granted a role still
+resolves every permission.
+<<[/UNRESOLVED]>>
+
+## Implementation History
+
+- (provisional) Summary and motivation drafted from staging signup analysis.

--- a/enhancements/platform/identity-and-access-management/policybinding-tuple-fanout/README.md
+++ b/enhancements/platform/identity-and-access-management/policybinding-tuple-fanout/README.md
@@ -18,15 +18,19 @@ Related: [datum-cloud/auth-provider-openfga](https://github.com/datum-cloud/auth
 - [Proposal](#proposal)
   - [How it works today](#how-it-works-today)
   - [The change](#the-change)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
 - [Design Details](#design-details)
   - [Authorization model](#authorization-model)
   - [Policy reconciler](#policy-reconciler)
   - [Migration](#migration)
-- [Risks and Mitigations](#risks-and-mitigations)
+- [Production Readiness Review Questionnaire](#production-readiness-review-questionnaire)
+  - [Feature Enablement and Rollback](#feature-enablement-and-rollback)
+  - [Monitoring Requirements](#monitoring-requirements)
+  - [Scalability](#scalability)
+- [Implementation History](#implementation-history)
 - [Drawbacks](#drawbacks)
 - [Alternatives](#alternatives)
-- [Open Questions](#open-questions)
-- [Implementation History](#implementation-history)
 
 ## Summary
 
@@ -139,6 +143,44 @@ not disappear. It moves into the authorization model, which is computed once and
 updated only when roles or protected resources change, rather than being copied
 into tuple storage on every binding.
 
+### Notes/Constraints/Caveats
+
+Two questions are still open and should be settled before this moves to
+`implementable`.
+
+<<[UNRESOLVED role-scoping ]>>
+Should role relations be added to every resource type, or only to the types a
+given role actually targets? The first is simpler; the second keeps the model
+smaller.
+<<[/UNRESOLVED]>>
+
+<<[UNRESOLVED groups ]>>
+Group-based subjects already resolve through `member`. Confirm the role-based
+path composes correctly with group membership so a group granted a role still
+resolves every permission.
+<<[/UNRESOLVED]>>
+
+### Risks and Mitigations
+
+The main risk is an authorization regression: a subtle difference between the
+old and new resolution paths could grant or deny something incorrectly.
+Mitigations:
+
+- Keep both representations valid at once so rollback is a reconciler flag, not a
+  data migration.
+- Add Check-equivalence tests that assert, for a representative set of subjects,
+  roles, and resources, that the role-based model returns the same decision as
+  the per-permission model.
+- Roll out on staging first and diff authorization decisions against production
+  behavior before backfilling.
+
+A secondary risk is model size. Unioning every permission over every role could
+make the model large. If that becomes a problem, scope role relations to the
+resource types a role actually targets rather than all types.
+
+Security review should be done by the IAM owners, since the change is entirely
+within the authorization boundary.
+
 ## Design Details
 
 ### Authorization model
@@ -182,23 +224,47 @@ The two representations resolve to the same Check results, so they can coexist:
 
 Each step is independently revertible.
 
-## Risks and Mitigations
+## Production Readiness Review Questionnaire
 
-The main risk is an authorization regression: a subtle difference between the
-old and new resolution paths could grant or deny something incorrectly.
-Mitigations:
+### Feature Enablement and Rollback
 
-- Keep both representations valid at once so rollback is a reconciler flag, not a
-  data migration.
-- Add Check-equivalence tests that assert, for a representative set of subjects,
-  roles, and resources, that the role-based model returns the same decision as
-  the per-permission model.
-- Roll out on staging first and diff authorization decisions against production
-  behavior before backfilling.
+- [x] Other
+  - Describe the mechanism: a reconciler-level flag selects whether a binding
+    writes role tuples or per-permission tuples. The authorization model carries
+    both role relations and per-permission relations, so either mode resolves
+    correctly.
+  - Will enabling / disabling the feature require downtime of the control plane?
+    No. It is a controller flag and takes effect on the next reconcile.
+  - Will enabling / disabling the feature require downtime or reprovisioning of a
+    node? No.
 
-A secondary risk is model size. Unioning every permission over every role could
-make the model large. If that becomes a problem, scope role relations to the
-resource types a role actually targets rather than all types.
+Enabling the feature changes the internal tuple representation but not any
+observable authorization decision. Disabling it after enablement is safe while
+per-permission relations remain in the model: bindings re-reconcile back to
+per-permission tuples. Re-enabling is equally safe and idempotent.
+
+### Monitoring Requirements
+
+An operator can tell the feature is working by watching the tuple count written
+per owner binding drop from 351 to 1, and by watching the time from organization
+creation to the owner PolicyBinding reaching `Ready` fall and tighten. A rollback
+signal would be any divergence in authorization decisions between the two modes,
+surfaced by the Check-equivalence tests, or a rise in `Check` latency caused by
+deeper model resolution.
+
+### Scalability
+
+The change removes API and storage load rather than adding it. Owner-binding
+tuple writes fall from 351 to 1, which reduces OpenFGA `Write` volume and
+`policybinding` reconcile time on the signup path. The tradeoff is a larger
+authorization model, bounded by (roles x permissions) and written once, plus
+potentially one extra resolution hop per `Check` as permissions resolve through
+a role. `Check` p99 is about 10ms today, so there is headroom, and this should
+be verified on staging before backfill.
+
+## Implementation History
+
+- (provisional) Summary and motivation drafted from staging signup analysis.
 
 ## Drawbacks
 
@@ -221,21 +287,3 @@ product behavior and does not address the general case of any broad role.
 **Precompute owner tuples at org creation.** Write the owner grant as part of
 org bootstrap rather than through a PolicyBinding. This narrows the fix to one
 role and leaves the fan-out in place for every other broad binding.
-
-## Open Questions
-
-<<[UNRESOLVED role-scoping ]>>
-Should role relations be added to every resource type, or only to the types a
-given role actually targets? The first is simpler; the second keeps the model
-smaller.
-<<[/UNRESOLVED]>>
-
-<<[UNRESOLVED groups ]>>
-Group-based subjects already resolve through `member`. Confirm the role-based
-path composes correctly with group membership so a group granted a role still
-resolves every permission.
-<<[/UNRESOLVED]>>
-
-## Implementation History
-
-- (provisional) Summary and motivation drafted from staging signup analysis.


### PR DESCRIPTION
## Summary

This adds a provisional IAM enhancement proposing that a PolicyBinding write a single role-assignment tuple instead of one OpenFGA tuple per (subject, permission).

The organization owner role grants every permission across the whole resource hierarchy, so a single owner binding expands to 351 tuples. That expansion sits on the signup critical path: a new user cannot use their organization until the owner grant has propagated, and the grant is 351 tuple writes behind a reconciler that processes bindings one at a time.

The proposal moves the fan-out out of tuple data and into the authorization model. A binding writes one "subject has role R on object" tuple, and the model expresses which permissions role R grants. The model is computed once and only changes when roles or protected resources change, so the per-binding cost drops from N tuples to one.

This PR is the design only. Implementation lives in [datum-cloud/auth-provider-openfga](https://github.com/datum-cloud/auth-provider-openfga) and would follow once the approach is agreed.

## Why we need it

Signup latency on staging is dominated by IAM propagation, and the owner grant is the single largest contributor. From controller and OpenFGA logs across three real signups on the same day:

| Signup      | Org owner ready | Project owner ready |
| ----------- | --------------- | ------------------- |
| `org-kzjnm` | +59s            | +82s                |
| `org-tbsxl` | +25s            | +47s                |
| `org-drc28` | +12s            | +37s                |

The 12s to 59s spread for the same operation tracks OpenFGA write latency and reconciler queue pressure, not user behavior. Supporting numbers from the same window: OpenFGA `Write` p99 about 990ms, `Check` p99 about 10ms, and `policybinding` reconcile p99 up to 3.4s on a bad day. The tuple count was confirmed directly from the teardown log line (`Successfully deleted tuples for PolicyBinding ... "tupleCount": 351`).

## Test plan

- [ ] IAM approvers review the proposed model change and migration path
- [ ] Confirm Check-equivalence approach is sufficient to catch authorization regressions before implementation starts
- [ ] Resolve the two open questions (role scoping, group composition)

## Notes for reviewers

The document is intentionally `provisional`. The two open questions are marked with `UNRESOLVED` blocks. Please push back on the migration ordering in particular, since the safety of the rollout depends on both representations resolving to identical Check results while they coexist.
