### PR TITLE
docs: tighten project-ready ceiling to 10s

### DIFF
--- a/enhancements/platform/convergence-slos/README.md
+++ b/enhancements/platform/convergence-slos/README.md
@@ -58,7 +58,7 @@ The initial set of user-facing convergence paths and their thresholds:
 
 | Convergence path | Signal that it converged | Reasonable-expectation threshold (proposed) |
 |---|---|---|
-| Project creates and becomes ready | project control plane accepts requests | 15s |
+| Project creates and becomes ready | project control plane accepts requests | 10s |
 | Organization onboarding completes | organization ready for use | 60s |
 | IAM policy binding takes effect | granted access is enforced | 15s |
 | Gateway programs | gateway Programmed with address assigned | 30s |
@@ -72,7 +72,7 @@ The initial set of user-facing convergence paths and their thresholds:
 
 The thresholds are derived from reasonable expectation, not from observation. Observed healthy convergence suggests a calibration; each number is then ratified by judging whether the wait is one a customer could reasonably expect. Where observed latency sits above what is reasonable to expect, the threshold holds and the gap is a defect to fix, not headroom to grant. The same judgment runs in the other direction: a ceiling sitting far above healthy latency is re-judged against what a customer would expect — interactive flows tighten toward seconds — rather than kept as slack.
 
-The contract is enforced at a stated percentile: alerts and dashboards gate on sustained p95 against the threshold, end-to-end tests on per-run convergence. Tail percentiles above the threshold are tracked as defects, not absorbed into a looser ceiling.
+The contract is enforced at a stated percentile: alerts and dashboards gate on sustained p95 against the threshold, end-to-end tests on per-run convergence. Tail percentiles above the threshold are tracked as defects, not absorbed into a looser ceiling. Outliers and tail defects do not hold a ceiling open: the threshold is set to the reasonable expectation and the outlier is fixed against it.
 
 The proposed numbers are seed calibrations from observed healthy convergence and existing per-path budgets; each should be validated against latency percentiles over more runs before enforcement, so the gate bounds expectation without introducing flake. Rows marked provisional have no healthy measurement yet and are set from the reasonable-expectation judgment alone. Where a path's observed latency today sits above its threshold — for example, domain verification rechecks that back off to hours — the threshold holds and the gap is a defect to fix. A composite journey (hostname created through resolving and serving traffic) is bounded by the sum of its component thresholds. The table is the artifact this enhancement delivers.
 


### PR DESCRIPTION
## Summary

Follow-up to datum-cloud/enhancements#829. Tightens the project-ready ceiling from 15s to 10s and makes one rule explicit: outliers and tail defects do not hold a ceiling open.

The 15s number was held back from 10s because the observed p99 tail sits above it. That got the derivation backwards — the ceiling is what a customer could reasonably expect (project creation is an interactive flow and should feel near-instant), and the tail is a defect tracked against the ceiling, not a constraint on it. Healthy p95 is single-digit seconds, so 10s is achievable.

Related to datum-cloud/infra#3692.

## Test plan

- [x] Table row and Design Details prose updated; no other content touched